### PR TITLE
feat: add management of `elb_policies_http_security`

### DIFF
--- a/.changelog/240.txt
+++ b/.changelog/240.txt
@@ -1,0 +1,7 @@
+```release-note:feature
+`elb` - Add methods to manage edgegateway load balancer http policies security.
+```
+
+```release-note:feature
+`elb` - Add methods to manage edgegateway load balancer http policies security.
+```

--- a/.changelog/240.txt
+++ b/.changelog/240.txt
@@ -1,7 +1,3 @@
 ```release-note:feature
 `elb` - Add methods to manage edgegateway load balancer http policies security.
 ```
-
-```release-note:feature
-`elb` - Add methods to manage edgegateway load balancer http policies security.
-```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,7 @@ linters:
   settings:
     staticcheck:
       checks:
+        - all
         - -QF1008
     revive:
       severity: error

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,10 +44,10 @@ linters:
     - staticcheck # Staticcheck is `go vet` on steroids [fast: false, auto-fix: false]
     - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
     - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
-    - usetesting # Use the testing package [fast: false, auto-fix: false]
     - wastedassign # Finds assignments to variables that are never used [fast: false, auto-fix: false]
     - whitespace # Checks for trailing whitespace [fast: true, auto-fix: false]
   disable:
+    - usetesting # Use the testing package [fast: false, auto-fix: false]
     - containedctx
     - cyclop
     - depguard
@@ -70,7 +70,6 @@ linters:
   settings:
     staticcheck:
       checks:
-        - all
         - -QF1008
     revive:
       severity: error

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/peterhellberg/link v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -82,6 +83,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect
 	google.golang.org/grpc v1.69.4 // indirect
 	google.golang.org/protobuf v1.36.3 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu5kc=
@@ -264,8 +266,9 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
 google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/helpers/validators/default.go
+++ b/pkg/helpers/validators/default.go
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package validators
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// URN is a validator that checks if a string is a valid URN (Uniform Resource Name).
+var Default = &CustomValidator{
+	Key: "default",
+	Func: func(fl validator.FieldLevel) bool {
+		if !fl.Field().IsZero() {
+			return true
+		}
+
+		k := fl.Field().Type().Kind()
+
+		switch k {
+		case reflect.String:
+			fl.Field().SetString(fl.Param())
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			i, err := strconv.Atoi(fl.Param())
+			if err != nil {
+				return false
+			}
+			fl.Field().SetInt(int64(i))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			i, err := strconv.ParseUint(fl.Param(), 10, 64)
+			if err != nil {
+				return false
+			}
+			fl.Field().SetUint(i)
+		case reflect.Float32, reflect.Float64:
+			f, err := strconv.ParseFloat(fl.Param(), 64)
+			if err != nil {
+				return false
+			}
+			fl.Field().SetFloat(f)
+		case reflect.Bool:
+			b, err := strconv.ParseBool(fl.Param())
+			if err != nil {
+				return false
+			}
+			fl.Field().SetBool(b)
+		default:
+
+			// If the field is not a string, int, or float, we can't set a default value
+			// and we should return false to indicate that the validation failed.
+			// Set the field to its nil value.
+			// fl.Field().Set(reflect.Zero(fl.Field().Type()))
+			return false
+		}
+
+		return true
+	},
+}

--- a/pkg/helpers/validators/default_test.go
+++ b/pkg/helpers/validators/default_test.go
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package validators_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/helpers/validators"
+)
+
+// validators_test.go test functions
+// This file contains the test functions for the validators package.
+// It includes tests for the Default validator, which sets default values for fields
+// based on their type and the provided parameter.
+// The tests cover various scenarios, including string, int, float, and bool types.
+// The tests also check for invalid cases where the field type does not match the expected type.
+
+type TestTypeString struct {
+	StringField string `validate:"default=default"`
+}
+type TestTypeInt struct {
+	// IntField     int     `/ validate:"default=42"`
+	// Int8Field    int8    `validate:"default=42"`
+	// Int16Field   int16   `validate:"default=42"`
+	// Int32Field   int32   `validate:"default=42"`
+	Int64Field int64 `validate:"default=42"`
+}
+type TestTypeUInt struct {
+	// UintField    uint    `validate:"default=42"`
+	// Uint8Field   uint8   `validate:"default=42"`
+	// Uint16Field  uint16  `validate:"default=42"`
+	// Uint32Field  uint32  `validate:"default=42"`
+	Uint64Field uint64 `validate:"default=42"`
+}
+type TestTypeFloat struct {
+	// Float32Field float32 `validate:"default=42.0"`
+	Float64Field float64 `validate:"default=42.0"`
+}
+type TestTypeBool struct {
+	BoolField bool `validate:"default=true"`
+}
+type TestTypeInvalidInt struct {
+	// IntField     int     `validate:"default=invalid"`
+	// Int8Field    int8    `validate:"default=invalid"`
+	// Int16Field   int16   `validate:"default=invalid"`
+	// Int32Field   int32   `validate:"default=invalid"`
+	Int64Field int64 `validate:"default=invalid"`
+}
+type TestTypeInvalidUInt struct {
+	// UintField    uint    `validate:"default=invalid"`
+	// Uint8Field   uint8   `validate:"default=invalid"`
+	// Uint16Field  uint16  `validate:"default=invalid"`
+	// Uint32Field  uint32  `validate:"default=invalid"`
+	Uint64Field uint64 `validate:"default=invalid"`
+}
+type TestTypeInvalidFloat struct {
+	// Float32Field float32 `validate:"default=invalid"`
+	Float64Field float64 `validate:"default=invalid"`
+}
+type TestTypeInvalidBool struct {
+	BoolField bool `validate:"default=invalid"`
+}
+
+type TestTypeNotvalid struct {
+	ArrayField []string `validate:"default=[]{\"default\"}"`
+	// MapField     map[string]string `validate:"default=invalid"`
+	// StructField  TestTypeString `validate:"default=invalid"`
+	// InterfaceField interface{} `validate:"default=invalid"`
+	// ChanField    chan string `validate:"default=invalid"`
+	// FuncField    func() `validate:"default=invalid"`
+	// ComplexField complex128 `validate:"default=invalid"`
+	// PtrField     *string `validate:"default=invalid"`
+}
+
+func TestDefaultValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name        string
+		input       interface{}
+		expected    interface{}
+		expectError bool
+	}
+
+	tests := []testCase{
+		{
+			name: "Valid default string",
+			input: &TestTypeString{
+				StringField: "",
+			},
+			expected: &TestTypeString{
+				StringField: "default",
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid default int64",
+			input: &TestTypeInt{
+				Int64Field: 0,
+			},
+			expected: &TestTypeInt{
+				Int64Field: 42,
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid default uint64",
+			input: &TestTypeUInt{
+				Uint64Field: 0,
+			},
+			expected: &TestTypeUInt{
+				Uint64Field: 42,
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid default float64",
+			input: &TestTypeFloat{
+				Float64Field: 0.0,
+			},
+			expected: &TestTypeFloat{
+				Float64Field: 42.0,
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid default bool",
+			input: &TestTypeBool{
+				BoolField: false,
+			},
+			expected: &TestTypeBool{
+				BoolField: true,
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid default int64",
+			input: &TestTypeInvalidInt{
+				Int64Field: 0,
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "Invalid default bool",
+			input: &TestTypeInvalidBool{
+				BoolField: false,
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "Invalid default uint64",
+			input: &TestTypeInvalidUInt{
+				Uint64Field: 0,
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "Invalid default float64",
+			input: &TestTypeInvalidFloat{
+				Float64Field: 0.0,
+			},
+			expected:    0.0,
+			expectError: true,
+		},
+		{
+			name: "Invalid default not valid",
+			input: &TestTypeNotvalid{
+				ArrayField: []string{},
+			},
+			expected: &TestTypeNotvalid{
+				ArrayField: []string{},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			validate := validators.New()
+			err := validate.Struct(test.input)
+
+			// Check if the validation error is expected
+			if test.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			// If we expect no error, but got one, fail the test
+			if err != nil {
+				// If we expect no error, but got one, fail the test
+				// and print the error message
+				t.Errorf("expected no error, got %v", err)
+			}
+
+			// Check if the input matches the expected value
+			if !reflect.DeepEqual(test.input, test.expected) {
+				t.Errorf("expected %v, got %v", test.expected, test.input)
+			}
+		})
+	}
+}

--- a/pkg/helpers/validators/validator.go
+++ b/pkg/helpers/validators/validator.go
@@ -28,5 +28,8 @@ func New() *validator.Validate {
 	_ = v.RegisterValidation(HTTPStatusCode.Key, HTTPStatusCode.Func)
 	_ = v.RegisterValidation(HTTPStatusCodeRange.Key, HTTPStatusCodeRange.Func)
 
+	// * Default
+	_ = v.RegisterValidation(Default.Key, Default.Func, true)
+
 	return v
 }

--- a/v1/edgegateway/edgegateway_test.go
+++ b/v1/edgegateway/edgegateway_test.go
@@ -10,7 +10,6 @@
 package edgegateway
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -521,7 +520,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.mockFunc()
 
-			edgeGateway, err := c.GetEdgeGateway(context.Background(), test.edgeGatewayNameOrID)
+			edgeGateway, err := c.GetEdgeGateway(t.Context(), test.edgeGatewayNameOrID)
 			if !test.expectedError {
 				assert.NoError(t, err)
 				assert.NotNil(t, edgeGateway)
@@ -717,7 +716,7 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.mockFunc()
 
-			allEdgeGateways, err := c.ListEdgeGateway(context.Background())
+			allEdgeGateways, err := c.ListEdgeGateway(t.Context())
 			if !test.expectedError {
 				assert.NoError(t, err)
 				assert.NotNil(t, allEdgeGateways)
@@ -867,7 +866,7 @@ func TestClient_UpdateEdgeGateway(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.mockFunc()
 
-			err := c.UpdateEdgeGateway(context.Background(), &EdgeGatewayModelUpdate{
+			err := c.UpdateEdgeGateway(t.Context(), &EdgeGatewayModelUpdate{
 				ID:        test.edgeID,
 				Bandwidth: test.bandwidth,
 			})
@@ -1076,7 +1075,7 @@ func TestClient_EnableNetworkService(t *testing.T) {
 				},
 			}
 
-			err := e.EnableNetworkService(context.Background())
+			err := e.EnableNetworkService(t.Context())
 			if !test.expectedError {
 				assert.NoError(t, err)
 				return
@@ -1284,7 +1283,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 				},
 			}
 
-			err := e.DisableNetworkService(context.Background())
+			err := e.DisableNetworkService(t.Context())
 			if !test.expectedError {
 				assert.NoError(t, err)
 				return
@@ -1537,7 +1536,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.mockFunc()
 
-			err := c.DeleteEdgeGateway(context.Background(), edgeGatewayID)
+			err := c.DeleteEdgeGateway(t.Context(), edgeGatewayID)
 			if !test.expectedError {
 				assert.NoError(t, err)
 				return

--- a/v1/edgeloadbalancer/client.go
+++ b/v1/edgeloadbalancer/client.go
@@ -54,6 +54,10 @@ type (
 		GetPoliciesHTTPResponse(ctx context.Context, virtualServiceID string) (*PoliciesHTTPResponseModel, error)
 		UpdatePoliciesHTTPResponse(ctx context.Context, policies *PoliciesHTTPResponseModel) (*PoliciesHTTPResponseModel, error)
 		DeletePoliciesHTTPResponse(ctx context.Context, virtualServiceID string) error
+		// ? Security
+		GetPoliciesHTTPSecurity(ctx context.Context, virtualServiceID string) (*PoliciesHTTPSecurityModel, error)
+		UpdatePoliciesHTTPSecurity(ctx context.Context, policies *PoliciesHTTPSecurityModel) (*PoliciesHTTPSecurityModel, error)
+		DeletePoliciesHTTPSecurity(ctx context.Context, virtualServiceID string) error
 	}
 
 	// Internal client interfaces.

--- a/v1/edgeloadbalancer/policies_http_const.go
+++ b/v1/edgeloadbalancer/policies_http_const.go
@@ -47,6 +47,9 @@ const (
 	PoliciesHTTPMethodMOVE      PoliciesHTTPMethod = "MOVE"
 	PoliciesHTTPMethodLOCK      PoliciesHTTPMethod = "LOCK"
 	PoliciesHTTPMethodUNLOCK    PoliciesHTTPMethod = "UNLOCK"
+
+	PoliciesHTTPConnectionActionALLOW PoliciesHTTPConnectionAction = "ALLOW"
+	PoliciesHTTPConnectionActionCLOSE PoliciesHTTPConnectionAction = "CLOSE"
 )
 
 // * Var HTTP.
@@ -126,7 +129,7 @@ var (
 	PoliciesHTTPLocationMatchCriteria       = PoliciesHTTPPathMatchCriteria
 	PoliciesHTTPLocationMatchCriteriaString = PoliciesHTTPPathMatchCriteriaString
 
-	PoliciesHTTPRequestHeaderMatchCriteria = []PoliciesHTTPMatchCriteriaCriteria{
+	PoliciesHTTPHeaderMatchCriteria = []PoliciesHTTPMatchCriteriaCriteria{
 		PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH,
 		PoliciesHTTPMatchCriteriaCriteriaDOESNOTBEGINWITH,
 		PoliciesHTTPMatchCriteriaCriteriaCONTAINS,
@@ -139,7 +142,7 @@ var (
 		PoliciesHTTPMatchCriteriaCriteriaDOESNOTEXIST,
 	}
 
-	PoliciesHTTPRequestHeaderMatchCriteriaString = sliceAnyToSliceString(PoliciesHTTPRequestHeaderMatchCriteria)
+	PoliciesHTTPHeaderMatchCriteriaString = sliceAnyToSliceString(PoliciesHTTPHeaderMatchCriteria)
 
 	PoliciesHTTPCookieMatchCriteria = []PoliciesHTTPMatchCriteriaCriteria{
 		PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH,
@@ -150,6 +153,8 @@ var (
 		PoliciesHTTPMatchCriteriaCriteriaDOESNOTENDWITH,
 		PoliciesHTTPMatchCriteriaCriteriaEQUALS,
 		PoliciesHTTPMatchCriteriaCriteriaDOESNOTEQUAL,
+		PoliciesHTTPMatchCriteriaCriteriaEXISTS,
+		PoliciesHTTPMatchCriteriaCriteriaDOESNOTEXIST,
 	}
 	PoliciesHTTPCookieMatchCriteriaString = sliceAnyToSliceString(PoliciesHTTPCookieMatchCriteria)
 )
@@ -178,4 +183,35 @@ var (
 		PoliciesHTTPMatchCriteriaCriteriaREGEXDOESNOTMATCH,
 	}
 	PoliciesHTTPResponseLocationHeaderMatchCriteriaString = sliceAnyToSliceString(PoliciesHTTPResponseLocationHeaderMatchCriteria)
+)
+
+// * Var for Connection.
+var (
+	PoliciesHTTPConnectionActions = []PoliciesHTTPConnectionAction{
+		PoliciesHTTPConnectionActionALLOW,
+		PoliciesHTTPConnectionActionCLOSE,
+	}
+	PoliciesHTTPConnectionActionsString = sliceAnyToSliceString(PoliciesHTTPConnectionActions)
+)
+
+// * Var for ActionSendReponseStatusCode.
+var (
+	PoliciesHTTPActionResponseStatusCodes       = []int64{200, 204, 403, 404, 429, 501}
+	PoliciesHTTPActionResponseStatusCodesString = sliceAnyToSliceString(PoliciesHTTPActionResponseStatusCodes)
+)
+
+// * Var for content type.
+var (
+	PoliciesHTTPActionContentTypes = []string{
+		"application/json",
+		"text/plain",
+		"text/html",
+	}
+	PoliciesHTTPActionContentTypesString = sliceAnyToSliceString(PoliciesHTTPActionContentTypes)
+)
+
+// * Var for RedirectStatusCode.
+var (
+	PoliciesHTTPRedirectStatusCodes       = []int64{301, 302, 307}
+	PoliciesHTTPRedirectStatusCodesString = sliceAnyToSliceString(PoliciesHTTPRedirectStatusCodes)
 )

--- a/v1/edgeloadbalancer/policies_http_request_test.go
+++ b/v1/edgeloadbalancer/policies_http_request_test.go
@@ -10,7 +10,6 @@
 package edgeloadbalancer
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -563,7 +562,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			policies, err := c.GetPoliciesHTTPRequest(context.Background(), tc.virtualServiceID)
+			policies, err := c.GetPoliciesHTTPRequest(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, policies)
@@ -1239,7 +1238,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			updatedPolicies, err := c.UpdatePoliciesHTTPRequest(context.Background(), tc.policies)
+			updatedPolicies, err := c.UpdatePoliciesHTTPRequest(t.Context(), tc.policies)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, tc.policies)
@@ -1369,7 +1368,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			err := c.DeletePoliciesHTTPRequest(context.Background(), tc.virtualServiceID)
+			err := c.DeletePoliciesHTTPRequest(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 			} else {

--- a/v1/edgeloadbalancer/policies_http_response_test.go
+++ b/v1/edgeloadbalancer/policies_http_response_test.go
@@ -10,7 +10,6 @@
 package edgeloadbalancer
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -621,7 +620,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			policies, err := c.GetPoliciesHTTPResponse(context.Background(), tc.virtualServiceID)
+			policies, err := c.GetPoliciesHTTPResponse(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, policies)
@@ -1411,7 +1410,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			updatedPolicies, err := c.UpdatePoliciesHTTPResponse(context.Background(), tc.policies)
+			updatedPolicies, err := c.UpdatePoliciesHTTPResponse(t.Context(), tc.policies)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, tc.policies)
@@ -1541,7 +1540,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			err := c.DeletePoliciesHTTPResponse(context.Background(), tc.virtualServiceID)
+			err := c.DeletePoliciesHTTPResponse(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 			} else {

--- a/v1/edgeloadbalancer/policies_http_security.go
+++ b/v1/edgeloadbalancer/policies_http_security.go
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package edgeloadbalancer
+
+import (
+	"context"
+	"fmt"
+
+	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/helpers/validators"
+)
+
+func (c *client) GetPoliciesHTTPSecurity(ctx context.Context, virtualServiceID string) (*PoliciesHTTPSecurityModel, error) {
+	if err := c.virtualServiceIDValidator(virtualServiceID); err != nil {
+		return nil, err
+	}
+
+	if err := c.clientCloudavenue.Refresh(); err != nil {
+		return nil, err
+	}
+
+	// * Get the virtual service
+	vs, err := c.getVirtualService(ctx, "", virtualServiceID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving virtual service: %w", err)
+	}
+
+	rules, err := getPoliciesHTTPSecurity(vs)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving HTTP request rules: %w", err)
+	}
+
+	return (&PoliciesHTTPSecurityModel{}).fromVCD(virtualServiceID, &govcdtypes.AlbVsHttpSecurityRules{
+		Values: func() (v []govcdtypes.AlbVsHttpSecurityRule) {
+			if rules == nil {
+				return nil
+			}
+
+			v = make([]govcdtypes.AlbVsHttpSecurityRule, len(rules))
+			for i := range rules {
+				v[i] = *rules[i]
+			}
+
+			return v
+		}(),
+	}), nil
+}
+
+var getPoliciesHTTPSecurity = func(virtualServiceClient fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+	return virtualServiceClient.GetAllHttpSecurityRules(nil)
+}
+
+func (c *client) UpdatePoliciesHTTPSecurity(ctx context.Context, policies *PoliciesHTTPSecurityModel) (*PoliciesHTTPSecurityModel, error) {
+	if err := validators.New().Struct(policies); err != nil {
+		return nil, err
+	}
+
+	if err := c.clientCloudavenue.Refresh(); err != nil {
+		return nil, err
+	}
+
+	// * Get the virtual service
+	vs, err := c.getVirtualService(ctx, "", policies.VirtualServiceID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving virtual service: %w", err)
+	}
+
+	policiesUpdated, err := updatePoliciesHTTPSecurity(vs, policies.toVCD())
+	if err != nil {
+		return nil, fmt.Errorf("error updating HTTP request rules: %w", err)
+	}
+
+	return policies.fromVCD(policies.VirtualServiceID, policiesUpdated), nil
+}
+
+var updatePoliciesHTTPSecurity = func(vs fakeVirtualServiceClient, policies *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+	policiesUpdated, err := vs.UpdateHttpSecurityRules(policies)
+	if err != nil {
+		return nil, fmt.Errorf("error updating HTTP request rules: %w", err)
+	}
+	return policiesUpdated, nil
+}
+
+func (c *client) DeletePoliciesHTTPSecurity(ctx context.Context, virtualServiceID string) error {
+	if err := c.virtualServiceIDValidator(virtualServiceID); err != nil {
+		return err
+	}
+
+	if err := c.clientCloudavenue.Refresh(); err != nil {
+		return err
+	}
+
+	// * Get the virtual service
+	vs, err := c.getVirtualService(ctx, "", virtualServiceID)
+	if err != nil {
+		return fmt.Errorf("error retrieving virtual service: %w", err)
+	}
+	_, err = updatePoliciesHTTPSecurity(vs, &govcdtypes.AlbVsHttpSecurityRules{})
+	if err != nil {
+		return fmt.Errorf("error deleting HTTP request rules: %w", err)
+	}
+
+	return nil
+}

--- a/v1/edgeloadbalancer/policies_http_security.go
+++ b/v1/edgeloadbalancer/policies_http_security.go
@@ -35,7 +35,7 @@ func (c *client) GetPoliciesHTTPSecurity(ctx context.Context, virtualServiceID s
 
 	rules, err := getPoliciesHTTPSecurity(vs)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving HTTP request rules: %w", err)
+		return nil, fmt.Errorf("error retrieving HTTP security rules: %w", err)
 	}
 
 	return (&PoliciesHTTPSecurityModel{}).fromVCD(virtualServiceID, &govcdtypes.AlbVsHttpSecurityRules{

--- a/v1/edgeloadbalancer/policies_http_security_test.go
+++ b/v1/edgeloadbalancer/policies_http_security_test.go
@@ -10,7 +10,6 @@
 package edgeloadbalancer
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -722,7 +721,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			policies, err := c.GetPoliciesHTTPSecurity(context.Background(), tc.virtualServiceID)
+			policies, err := c.GetPoliciesHTTPSecurity(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, policies)
@@ -755,17 +754,50 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 	serviceEngineID := urn.ServiceEngineGroup.String() + uuid.New().String()
 
 	tests := []struct {
-		name        string
-		policies    *PoliciesHTTPSecurityModel
-		mockFunc    func()
-		expectedErr bool
-		err         error
+		name             string
+		policies         *PoliciesHTTPSecurityModel
+		expectedPolicies *PoliciesHTTPSecurityModel
+		mockFunc         func()
+		expectedErr      bool
+		err              error
 	}{
 		// ? ------------------------------------------------------------------------------
 		// ? ------------------------------ SUCCESS CASES ---------------------------------
 		{
 			name: "success",
 			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName2",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
@@ -911,13 +943,511 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 			expectedErr: false,
 			err:         nil,
 		},
+		{
+			name: "success_default",
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:  "HTTP",
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+						},
+						// RedirectToHTTPSAction: utils.ToPTR(8443),
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							CloseConnectionAction: utils.ToPTR(true),
+						},
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName3",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+							},
+							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+								// Count:                 1000,
+								// Period:                60,
+								CloseConnectionAction: "CLOSE",
+							},
+						},
+					}, nil
+				}
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, v *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return v, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:  "HTTP",
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+						},
+						// RedirectToHTTPSAction: utils.ToPTR(8443),
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:                 1000,
+							Period:                60,
+							CloseConnectionAction: utils.ToPTR(true),
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		{
+			name: "success-rate-limit-action-redirect",
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol: "HTTP",
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							RedirectAction: &PoliciesHTTPActionRedirect{
+								Host:       "example.com",
+								KeepQuery:  true,
+								Protocol:   "HTTPS",
+								Port:       utils.ToPTR(443),
+								StatusCode: 302,
+							},
+						},
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName3",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								Protocol: "HTTP",
+							},
+							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+								Count:  100,
+								Period: 60,
+								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
+									Host:       "example.com",
+									KeepQuery:  true,
+									Protocol:   "HTTPS",
+									Port:       utils.ToPTR(443),
+									StatusCode: 302,
+								},
+							},
+						},
+					}, nil
+				}
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, v *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return v, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol: "HTTP",
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							RedirectAction: &PoliciesHTTPActionRedirect{
+								Host:       "example.com",
+								KeepQuery:  true,
+								Protocol:   "HTTPS",
+								Port:       utils.ToPTR(443),
+								StatusCode: 302,
+							},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		{
+			name: "success-rate-limit-action-local-response",
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol: "HTTP",
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							LocalResponseAction: &PoliciesHTTPActionSendResponse{
+								StatusCode:  404,
+								ContentType: "application/json",
+								Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+							},
+						},
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName3",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								Protocol: "HTTP",
+							},
+							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+								Count:  100,
+								Period: 60,
+								LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
+									StatusCode:  404,
+									ContentType: "application/json",
+									Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+								},
+							},
+						},
+					}, nil
+				}
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, v *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return v, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol: "HTTP",
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							LocalResponseAction: &PoliciesHTTPActionSendResponse{
+								StatusCode:  404,
+								ContentType: "application/json",
+								Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+							},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ ERROR CASES -----------------------------------
+		{
+			name:        "error-refresh",
+			expectedErr: true,
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+		{
+			name: "error-validation-model",
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName3",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			mockFunc:    func() {},
+			expectedErr: true,
+			err:         errors.New("Error:Field validation"),
+		},
+		{
+			name:        "error-getVirtualService",
+			expectedErr: true,
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName2",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(nil, errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+		{
+			name:        "error-updatePoliciesHTTPRequest",
+			expectedErr: true,
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName2",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{}, nil)
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, _ *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return nil, errors.New("error")
+				}
+			},
+			err: errors.New("error"),
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			updatedPolicies, err := c.UpdatePoliciesHTTPSecurity(context.Background(), tc.policies)
+			updatedPolicies, err := c.UpdatePoliciesHTTPSecurity(t.Context(), tc.policies)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 				assert.NotNil(t, tc.policies)
@@ -928,7 +1458,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.policies, updatedPolicies)
+			assert.Equal(t, tc.expectedPolicies, updatedPolicies)
 		})
 	}
 }
@@ -1051,7 +1581,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.mockFunc()
 
-			err := c.DeletePoliciesHTTPSecurity(context.Background(), tc.virtualServiceID)
+			err := c.DeletePoliciesHTTPSecurity(t.Context(), tc.virtualServiceID)
 			if !tc.expectedErr {
 				assert.NoError(t, err)
 			} else {

--- a/v1/edgeloadbalancer/policies_http_security_test.go
+++ b/v1/edgeloadbalancer/policies_http_security_test.go
@@ -1,0 +1,1066 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package edgeloadbalancer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/internal/utils"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
+)
+
+func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
+	// Mock controller.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mock client for cloudavenue.
+	clientCAV := NewMockclientFake(ctrl)
+
+	c, _ := NewFakeClient(clientCAV)
+
+	virtualServiceID := urn.LoadBalancerVirtualService.String() + uuid.New().String()
+	edgeGatewayID := urn.Gateway.String() + uuid.New().String()
+	poolID := urn.LoadBalancerPool.String() + uuid.New().String()
+	serviceEngineID := urn.ServiceEngineGroup.String() + uuid.New().String()
+
+	tests := []struct {
+		name             string
+		virtualServiceID string
+		mockFunc         func()
+		expectedPolicies *PoliciesHTTPSecurityModel
+		expectedErr      bool
+		err              error
+	}{
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ SUCCESS CASES ---------------------------------
+		{
+			name:             "success-action-redirect-to-https",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
+									MatchCriteria: "IS_IN",
+									Addresses: []string{
+										"12.23.34.45",
+										"12.23.34.0/24",
+										"12.23.34.0-12.23.34.100",
+									},
+								},
+								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
+									MatchCriteria: "IS_IN",
+									Ports: []int{
+										80,
+										443,
+									},
+								},
+								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
+									MatchCriteria: "IS_IN",
+									Methods: []string{
+										"GET",
+										"POST",
+									},
+								},
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+								QueryMatch: []string{
+									"key1=value1",
+									"key2=value2",
+								},
+								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "User-Agent",
+										Value: []string{
+											"Mozilla/5.0",
+											"curl/7.64.1",
+										},
+									},
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "Accept",
+										Value: []string{
+											"application/json",
+											"text/html",
+										},
+									},
+								},
+								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
+									MatchCriteria: "BEGINS_WITH",
+									Key:           "session_id",
+									Value:         "abc123",
+								},
+							},
+							RedirectToHTTPSAction: &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{
+								Port: 8443,
+							},
+						},
+					}, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		{
+			name:             "success-action-send-response",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
+									MatchCriteria: "IS_IN",
+									Addresses: []string{
+										"12.23.34.45",
+										"12.23.34.0/24",
+										"12.23.34.0-12.23.34.100",
+									},
+								},
+								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
+									MatchCriteria: "IS_IN",
+									Ports: []int{
+										80,
+										443,
+									},
+								},
+								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
+									MatchCriteria: "IS_IN",
+									Methods: []string{
+										"GET",
+										"POST",
+									},
+								},
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+								QueryMatch: []string{
+									"key1=value1",
+									"key2=value2",
+								},
+								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "User-Agent",
+										Value: []string{
+											"Mozilla/5.0",
+											"curl/7.64.1",
+										},
+									},
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "Accept",
+										Value: []string{
+											"application/json",
+											"text/html",
+										},
+									},
+								},
+								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
+									MatchCriteria: "BEGINS_WITH",
+									Key:           "session_id",
+									Value:         "abc123",
+								},
+							},
+							LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
+								StatusCode:  404,
+								ContentType: "application/json",
+								Content:     "{\"key\":\"value\"}",
+							},
+						},
+					}, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						SendResponseAction: &PoliciesHTTPActionSendResponse{
+							StatusCode:  404,
+							ContentType: "application/json",
+							Content:     "{\"key\":\"value\"}",
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		{
+			name:             "success-action-rate-limit-action-redirect",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
+									MatchCriteria: "IS_IN",
+									Addresses: []string{
+										"12.23.34.45",
+										"12.23.34.0/24",
+										"12.23.34.0-12.23.34.100",
+									},
+								},
+								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
+									MatchCriteria: "IS_IN",
+									Ports: []int{
+										80,
+										443,
+									},
+								},
+								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
+									MatchCriteria: "IS_IN",
+									Methods: []string{
+										"GET",
+										"POST",
+									},
+								},
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+								QueryMatch: []string{
+									"key1=value1",
+									"key2=value2",
+								},
+								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "User-Agent",
+										Value: []string{
+											"Mozilla/5.0",
+											"curl/7.64.1",
+										},
+									},
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "Accept",
+										Value: []string{
+											"application/json",
+											"text/html",
+										},
+									},
+								},
+								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
+									MatchCriteria: "BEGINS_WITH",
+									Key:           "session_id",
+									Value:         "abc123",
+								},
+							},
+							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+								Count:  100,
+								Period: 60,
+								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
+									Host:       "example.com",
+									KeepQuery:  true,
+									Protocol:   "HTTPS",
+									Port:       utils.ToPTR(443),
+									StatusCode: 302,
+									Path:       "/newpath",
+								},
+							},
+						},
+					}, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							RedirectAction: &PoliciesHTTPActionRedirect{
+								Host:       "example.com",
+								KeepQuery:  true,
+								Protocol:   "HTTPS",
+								Port:       utils.ToPTR(443),
+								StatusCode: 302,
+								Path:       "/newpath",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		{
+			name:             "success-action-rate-limit-action-local-response",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
+									MatchCriteria: "IS_IN",
+									Addresses: []string{
+										"12.23.34.45",
+										"12.23.34.0/24",
+										"12.23.34.0-12.23.34.100",
+									},
+								},
+								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
+									MatchCriteria: "IS_IN",
+									Ports: []int{
+										80,
+										443,
+									},
+								},
+								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
+									MatchCriteria: "IS_IN",
+									Methods: []string{
+										"GET",
+										"POST",
+									},
+								},
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+								QueryMatch: []string{
+									"key1=value1",
+									"key2=value2",
+								},
+								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "User-Agent",
+										Value: []string{
+											"Mozilla/5.0",
+											"curl/7.64.1",
+										},
+									},
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "Accept",
+										Value: []string{
+											"application/json",
+											"text/html",
+										},
+									},
+								},
+								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
+									MatchCriteria: "BEGINS_WITH",
+									Key:           "session_id",
+									Value:         "abc123",
+								},
+							},
+							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+								Count:  100,
+								Period: 60,
+								LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
+									StatusCode:  404,
+									ContentType: "application/json",
+									Content:     "{\"key\":\"value\"}",
+								},
+							},
+						},
+					}, nil
+				}
+			},
+			expectedPolicies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RateLimitAction: &PoliciesHTTPActionRateLimit{
+							Count:  100,
+							Period: 60,
+							LocalResponseAction: &PoliciesHTTPActionSendResponse{
+								StatusCode:  404,
+								ContentType: "application/json",
+								Content:     "{\"key\":\"value\"}",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ ERROR CASES -----------------------------------
+		{
+			name:             "error-refresh",
+			expectedErr:      true,
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+		{
+			name:             "error-virtualserviceValidation",
+			expectedErr:      true,
+			virtualServiceID: "",
+			mockFunc: func() {
+			},
+			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
+		},
+		{
+			name:             "error-getVirtualService",
+			expectedErr:      true,
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(nil, errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+		{
+			name:             "error-getPoliciesHTTPSecurity",
+			expectedErr:      true,
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return nil, errors.New("error")
+				}
+			},
+			err: errors.New("error"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+
+			policies, err := c.GetPoliciesHTTPSecurity(context.Background(), tc.virtualServiceID)
+			if !tc.expectedErr {
+				assert.NoError(t, err)
+				assert.NotNil(t, policies)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err.Error())
+				assert.Nil(t, policies)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedPolicies, policies)
+		})
+	}
+}
+
+func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
+	// Mock controller.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mock client for cloudavenue.
+	clientCAV := NewMockclientFake(ctrl)
+
+	c, _ := NewFakeClient(clientCAV)
+
+	virtualServiceID := urn.LoadBalancerVirtualService.String() + uuid.New().String()
+	edgeGatewayID := urn.Gateway.String() + uuid.New().String()
+	poolID := urn.LoadBalancerPool.String() + uuid.New().String()
+	serviceEngineID := urn.ServiceEngineGroup.String() + uuid.New().String()
+
+	tests := []struct {
+		name        string
+		policies    *PoliciesHTTPSecurityModel
+		mockFunc    func()
+		expectedErr bool
+		err         error
+	}{
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ SUCCESS CASES ---------------------------------
+		{
+			name: "success",
+			policies: &PoliciesHTTPSecurityModel{
+				VirtualServiceID: virtualServiceID,
+				Policies: []*PoliciesHTTPSecurityModelPolicy{
+					{
+						Name:    "ruleName2",
+						Active:  true,
+						Logging: true,
+						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
+							Protocol:         "HTTP",
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							HeaderMatch: []PoliciesHTTPHeaderMatch{
+								{
+									Criteria: "IS_IN",
+									Name:     "User-Agent",
+									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+								},
+								{
+									Criteria: "IS_IN",
+									Name:     "Accept",
+									Values:   []string{"application/json", "text/html"},
+								},
+							},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+						},
+						RedirectToHTTPSAction: utils.ToPTR(8443),
+					},
+				},
+			},
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
+					return []*govcdtypes.AlbVsHttpSecurityRule{
+						{
+							Name:    "ruleName",
+							Active:  true,
+							Logging: true,
+							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
+									MatchCriteria: "IS_IN",
+									Addresses: []string{
+										"12.23.34.45",
+										"12.23.34.0/24",
+										"12.23.34.0-12.23.34.100",
+									},
+								},
+								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
+									MatchCriteria: "IS_IN",
+									Ports: []int{
+										80,
+										443,
+									},
+								},
+								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
+									MatchCriteria: "IS_IN",
+									Methods: []string{
+										"GET",
+										"POST",
+									},
+								},
+								Protocol: "HTTP",
+								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
+									MatchCriteria: "BEGINS_WITH",
+									MatchStrings: []string{
+										"/path1",
+										"/path2",
+									},
+								},
+								QueryMatch: []string{
+									"key1=value1",
+									"key2=value2",
+								},
+								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "User-Agent",
+										Value: []string{
+											"Mozilla/5.0",
+											"curl/7.64.1",
+										},
+									},
+									{
+										MatchCriteria: "IS_IN",
+										Key:           "Accept",
+										Value: []string{
+											"application/json",
+											"text/html",
+										},
+									},
+								},
+								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
+									MatchCriteria: "BEGINS_WITH",
+									Key:           "session_id",
+									Value:         "abc123",
+								},
+							},
+							RedirectToHTTPSAction: &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{
+								Port: 8443,
+							},
+						},
+					}, nil
+				}
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, v *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return v, nil
+				}
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+
+			updatedPolicies, err := c.UpdatePoliciesHTTPSecurity(context.Background(), tc.policies)
+			if !tc.expectedErr {
+				assert.NoError(t, err)
+				assert.NotNil(t, tc.policies)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.policies, updatedPolicies)
+		})
+	}
+}
+
+func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
+	// Mock controller.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mock client for cloudavenue.
+	clientCAV := NewMockclientFake(ctrl)
+
+	c, _ := NewFakeClient(clientCAV)
+
+	virtualServiceID := urn.LoadBalancerVirtualService.String() + uuid.New().String()
+	edgeGatewayID := urn.Gateway.String() + uuid.New().String()
+	poolID := urn.LoadBalancerPool.String() + uuid.New().String()
+	serviceEngineID := urn.ServiceEngineGroup.String() + uuid.New().String()
+
+	tests := []struct {
+		name             string
+		virtualServiceID string
+		mockFunc         func()
+		expectedErr      bool
+		err              error
+	}{
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ SUCCESS CASES ---------------------------------
+		{
+			name:             "success",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
+					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
+						ID:          virtualServiceID,
+						Name:        "virtualServiceName2",
+						Description: "virtualServiceDescription2",
+						Enabled:     utils.ToPTR(true),
+						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
+							Type: "HTTPS",
+						},
+						GatewayRef: govcdtypes.OpenApiReference{
+							ID: edgeGatewayID,
+						},
+						LoadBalancerPoolRef: govcdtypes.OpenApiReference{
+							ID: poolID,
+						},
+						ServiceEngineGroupRef: govcdtypes.OpenApiReference{
+							ID: serviceEngineID,
+						},
+						ServicePorts: []govcdtypes.NsxtAlbVirtualServicePort{
+							{
+								PortStart:  utils.ToPTR(443),
+								PortEnd:    nil,
+								SslEnabled: utils.ToPTR(true),
+								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
+									Type: "TCP_PROXY",
+								},
+							},
+						},
+						VirtualIpAddress:      "192.168.0.1",
+						HealthStatus:          "UP",
+						HealthMessage:         "OK",
+						DetailedHealthMessage: "OK",
+					},
+				}, nil)
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, _ *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return &govcdtypes.AlbVsHttpSecurityRules{}, nil
+				}
+			},
+			expectedErr: false,
+			err:         nil,
+		},
+		// ? ------------------------------------------------------------------------------
+		// ? ------------------------------ ERROR CASES -----------------------------------
+		{
+			name:             "error-delete",
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{}, nil)
+				updatePoliciesHTTPSecurity = func(_ fakeVirtualServiceClient, _ *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error) {
+					return &govcdtypes.AlbVsHttpSecurityRules{}, errors.New("error")
+				}
+			},
+			expectedErr: true,
+			err:         errors.New("error"),
+		},
+		{
+			name:             "error-refresh",
+			expectedErr:      true,
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+		{
+			name:             "error-virtualserviceValidation",
+			expectedErr:      true,
+			virtualServiceID: "",
+			mockFunc: func() {
+			},
+			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
+		},
+		{
+			name:             "error-getVirtualService",
+			expectedErr:      true,
+			virtualServiceID: virtualServiceID,
+			mockFunc: func() {
+				clientCAV.EXPECT().Refresh().Return(nil)
+				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(nil, errors.New("error"))
+			},
+			err: errors.New("error"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+
+			err := c.DeletePoliciesHTTPSecurity(context.Background(), tc.virtualServiceID)
+			if !tc.expectedErr {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/v1/edgeloadbalancer/policies_http_security_types.go
+++ b/v1/edgeloadbalancer/policies_http_security_types.go
@@ -1,0 +1,234 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package edgeloadbalancer
+
+import (
+	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+type (
+	PoliciesHTTPSecurityModel struct {
+		VirtualServiceID string `validate:"required,urn=loadBalancerVirtualService"`
+		// List of HTTP Request Policies
+		Policies []*PoliciesHTTPSecurityModelPolicy `validate:"required,dive"`
+	}
+
+	PoliciesHTTPSecurityModelPolicy struct {
+		// Name of the rule
+		Name string `validate:"required"`
+		// Whether the rule is active or not.
+		Active bool `validate:"omitempty"`
+		// Whether to enable logging for the rule (policy)
+		Logging bool `validate:"omitempty"`
+		// MatchCriteria for the HTTP Request
+		MatchCriteria PoliciesHTTPSecurityMatchCriteria `validate:"required"`
+
+		// Action to take when the rule matches
+
+		// HTTP Connection Action
+		// It can be configured in combination with other actions
+		ConnectionAction string `validate:"omitempty,oneof=ALLOW CLOSE"`
+		// HTTP Rate Limit Action
+		// It can be configured in combination with other actions
+		RateLimitAction *PoliciesHTTPActionRateLimit `validate:"omitempty"`
+		// HTTP Redirect to HTTPS Action
+		// It can be configured in combination with other actions
+		// RedirectToHTTPSAction *PoliciesHTTPActionRedirectToHTTPS `validate:"omitempty"`
+		RedirectToHTTPSAction *int `validate:"omitempty"`
+		// HTTP Send Response Action
+		// It can be configured in combination with other actions
+		SendResponseAction *PoliciesHTTPActionSendResponse `validate:"omitempty"`
+	}
+
+	PoliciesHTTPSecurityMatchCriteria struct {
+		// Protocol
+		Protocol string `validate:"omitempty,oneof=HTTP HTTPS"`
+		// Client IP addresses
+		ClientIPMatch *PoliciesHTTPClientIPMatch `validate:"omitempty"`
+		// Service Ports
+		ServicePortMatch *PoliciesHTTPServicePortMatch `validate:"omitempty"`
+		// HTTP Methods
+		MethodMatch *PoliciesHTTPMethodMatch `validate:"omitempty"`
+		// Path Match
+		PathMatch *PoliciesHTTPPathMatch `validate:"omitempty"`
+		// HTTP request cookies
+		CookieMatch *PoliciesHTTPCookieMatch `validate:"omitempty"`
+		// HTTP request headers
+		HeaderMatch PoliciesHTTPHeadersMatch `validate:"omitempty"`
+		// HTTP request query strings in key=value format
+		QueryMatch []string `validate:"omitempty,dive,str_key_value"`
+	}
+)
+
+// * Helpers to convert PoliciesHTTPSecurityModel to and from vCD types
+
+func (PoliciesHTTPSecurityModel) fromVCD(virtualServiceID string, rules *govcdtypes.AlbVsHttpSecurityRules) *PoliciesHTTPSecurityModel {
+	x := &PoliciesHTTPSecurityModel{
+		VirtualServiceID: virtualServiceID,
+	}
+
+	for _, rule := range rules.Values {
+		x.Policies = append(x.Policies, (&PoliciesHTTPSecurityModelPolicy{}).fromVCD(&rule))
+	}
+	return x
+}
+
+func (p *PoliciesHTTPSecurityModel) toVCD() *govcdtypes.AlbVsHttpSecurityRules {
+	m := &govcdtypes.AlbVsHttpSecurityRules{}
+
+	var rules []govcdtypes.AlbVsHttpSecurityRule
+	for _, policy := range p.Policies {
+		rules = append(rules, policy.toVCD())
+	}
+
+	m.Values = rules
+
+	return m
+}
+
+// * Helpers to convert PoliciesHTTPSecurityModelPolicy to and from vCD types
+
+func (PoliciesHTTPSecurityModelPolicy) fromVCD(rule *govcdtypes.AlbVsHttpSecurityRule) *PoliciesHTTPSecurityModelPolicy {
+	return &PoliciesHTTPSecurityModelPolicy{
+		Name:             rule.Name,
+		Active:           rule.Active,
+		Logging:          rule.Logging,
+		MatchCriteria:    PoliciesHTTPSecurityMatchCriteria{}.fromVCD(rule.MatchCriteria),
+		ConnectionAction: rule.AllowOrCloseConnectionAction,
+		RedirectToHTTPSAction: func() *int {
+			if rule.RedirectToHTTPSAction != nil {
+				return &rule.RedirectToHTTPSAction.Port
+			}
+			return nil
+		}(),
+		SendResponseAction: (&PoliciesHTTPActionSendResponse{}).fromVCD(rule.LocalResponseAction),
+		RateLimitAction:    (&PoliciesHTTPActionRateLimit{}).fromVCD(rule.RateLimitAction),
+	}
+}
+
+func (p *PoliciesHTTPSecurityModelPolicy) toVCD() govcdtypes.AlbVsHttpSecurityRule {
+	return govcdtypes.AlbVsHttpSecurityRule{
+		Name:                         p.Name,
+		Active:                       p.Active,
+		Logging:                      p.Logging,
+		MatchCriteria:                p.MatchCriteria.toVCD(),
+		AllowOrCloseConnectionAction: p.ConnectionAction,
+		RedirectToHTTPSAction:        &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{Port: *p.RedirectToHTTPSAction},
+		LocalResponseAction:          p.SendResponseAction.toVCD(),
+		RateLimitAction:              p.RateLimitAction.toVCD(),
+	}
+}
+
+// * Helpers to convert PoliciesHTTPSecurityMatchCriteria to and from vCD types
+
+func (PoliciesHTTPSecurityMatchCriteria) fromVCD(criteria govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria) PoliciesHTTPSecurityMatchCriteria {
+	return PoliciesHTTPSecurityMatchCriteria{
+		Protocol:         criteria.Protocol,
+		ClientIPMatch:    (&PoliciesHTTPClientIPMatch{}).fromVCD(criteria.ClientIPMatch),
+		ServicePortMatch: (&PoliciesHTTPServicePortMatch{}).fromVCD(criteria.ServicePortMatch),
+		MethodMatch:      (&PoliciesHTTPMethodMatch{}).fromVCD(criteria.MethodMatch),
+		PathMatch:        (&PoliciesHTTPPathMatch{}).fromVCD(criteria.PathMatch),
+		CookieMatch:      (&PoliciesHTTPCookieMatch{}).fromVCD(criteria.CookieMatch),
+		HeaderMatch:      (&PoliciesHTTPHeadersMatch{}).fromVCD(criteria.HeaderMatch),
+		QueryMatch:       criteria.QueryMatch,
+	}
+}
+
+func (p PoliciesHTTPSecurityMatchCriteria) toVCD() govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria {
+	return govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
+		Protocol:         p.Protocol,
+		ClientIPMatch:    p.ClientIPMatch.toVCD(),
+		ServicePortMatch: p.ServicePortMatch.toVCD(),
+		MethodMatch:      p.MethodMatch.toVCD(),
+		PathMatch:        p.PathMatch.toVCD(),
+		CookieMatch:      p.CookieMatch.toVCD(),
+		HeaderMatch:      p.HeaderMatch.toVCD(),
+		QueryMatch:       p.QueryMatch,
+	}
+}
+
+// * Helpers to convert PoliciesHTTPActionRateLimit to and from vCD types
+
+func (PoliciesHTTPActionRateLimit) fromVCD(action *govcdtypes.AlbVsHttpSecurityRuleRateLimitAction) *PoliciesHTTPActionRateLimit {
+	if action == nil {
+		return nil
+	}
+	return &PoliciesHTTPActionRateLimit{
+		Count:  action.Count,
+		Period: action.Period,
+		RedirectAction: func() *PoliciesHTTPActionRedirect {
+			if action.RedirectAction != nil {
+				return (&PoliciesHTTPActionRedirect{}).fromVCD(action.RedirectAction)
+			}
+			return nil
+		}(),
+		LocalResponseAction: func() *PoliciesHTTPActionSendResponse {
+			if action.LocalResponseAction != nil {
+				return (&PoliciesHTTPActionSendResponse{}).fromVCD(action.LocalResponseAction)
+			}
+			return nil
+		}(),
+		CloseConnectionAction: func() string {
+			if action.CloseConnectionAction != "" {
+				return "Close_Connection"
+			}
+			return ""
+		}(),
+	}
+}
+
+func (p *PoliciesHTTPActionRateLimit) toVCD() *govcdtypes.AlbVsHttpSecurityRuleRateLimitAction {
+	if p == nil {
+		return nil
+	}
+	return &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+		Count:  p.Count,
+		Period: p.Period,
+		CloseConnectionAction: func() string {
+			return p.CloseConnectionAction
+		}(),
+		RedirectAction: func() *govcdtypes.AlbVsHttpRequestRuleRedirectAction {
+			if p.RedirectAction != nil {
+				return p.RedirectAction.toVCD()
+			}
+			return nil
+		}(),
+		LocalResponseAction: func() *govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction {
+			if p.LocalResponseAction != nil {
+				return p.LocalResponseAction.toVCD()
+			}
+			return nil
+		}(),
+	}
+}
+
+// * Helpers to convert PoliciesHTTPActionSendResponse to and from vCD types
+
+func (PoliciesHTTPActionSendResponse) fromVCD(action *govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction) *PoliciesHTTPActionSendResponse {
+	if action == nil {
+		return nil
+	}
+	return &PoliciesHTTPActionSendResponse{
+		StatusCode:  action.StatusCode,
+		ContentType: action.ContentType,
+		Content:     action.Content,
+	}
+}
+
+func (p *PoliciesHTTPActionSendResponse) toVCD() *govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction {
+	if p == nil {
+		return nil
+	}
+	return &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
+		Content:     p.Content,
+		ContentType: p.ContentType,
+		StatusCode:  p.StatusCode,
+	}
+}

--- a/v1/edgeloadbalancer/policies_http_security_types.go
+++ b/v1/edgeloadbalancer/policies_http_security_types.go
@@ -120,9 +120,14 @@ func (p *PoliciesHTTPSecurityModelPolicy) toVCD() govcdtypes.AlbVsHttpSecurityRu
 		Logging:                      p.Logging,
 		MatchCriteria:                p.MatchCriteria.toVCD(),
 		AllowOrCloseConnectionAction: p.ConnectionAction,
-		RedirectToHTTPSAction:        &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{Port: *p.RedirectToHTTPSAction},
-		LocalResponseAction:          p.SendResponseAction.toVCD(),
-		RateLimitAction:              p.RateLimitAction.toVCD(),
+		RedirectToHTTPSAction: func() *govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction {
+			if p.RedirectToHTTPSAction != nil {
+				return &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{Port: *p.RedirectToHTTPSAction}
+			}
+			return nil
+		}(),
+		LocalResponseAction: p.SendResponseAction.toVCD(),
+		RateLimitAction:     p.RateLimitAction.toVCD(),
 	}
 }
 

--- a/v1/edgeloadbalancer/policies_http_types_actions.go
+++ b/v1/edgeloadbalancer/policies_http_types_actions.go
@@ -63,6 +63,36 @@ type (
 		// Whether or not to keep the existing query string when rewriting the URL. Defaults to true.
 		KeepQuery bool `validate:"omitempty"`
 	}
+
+	// PoliciesHTTPActionRedirectToHTTPS struct {
+	// 	// The port must be between 1 to 65535
+	// 	Port int
+	// }
+
+	PoliciesHTTPActionRateLimit struct {
+		// Maximum number of requests per period allowed 1 to 1000000000
+		Count int `validate:"required"`
+		// Time period in seconds for the rate limit 1 to 1000000000
+		Period int `validate:"required"`
+		// Action to take when the rate limit is exceeded
+		RedirectAction *PoliciesHTTPActionRedirect `validate:"omitempty"`
+		// Action to take when the rate limit is exceeded
+		CloseConnectionAction string `validate:"omitempty"`
+		// Action to take when the rate limit is exceeded
+		LocalResponseAction *PoliciesHTTPActionSendResponse `validate:"omitempty"`
+		// Action to take when the rate limit is exceeded
+		// RepportOnlyAction bool `validate:"omitempty"`
+		// Action string `validate:"required,oneof=Close_Connection Redirect Local_Response"`
+	}
+
+	PoliciesHTTPActionSendResponse struct {
+		// HTTP status code to return
+		StatusCode int `validate:"required,oneof=200 204 403 404 429 501"`
+		// Content type of the response
+		ContentType string `validate:"required,oneof=application/json text/html text/plain"`
+		// Content of the response
+		Content string `validate:"required"`
+	}
 )
 
 // * Helpers to convert PoliciesHTTPActionHeaderRewrite to and from vCD types

--- a/v1/edgeloadbalancer/policies_http_types_actions.go
+++ b/v1/edgeloadbalancer/policies_http_types_actions.go
@@ -80,9 +80,6 @@ type (
 		CloseConnectionAction string `validate:"omitempty"`
 		// Action to take when the rate limit is exceeded
 		LocalResponseAction *PoliciesHTTPActionSendResponse `validate:"omitempty"`
-		// Action to take when the rate limit is exceeded
-		// RepportOnlyAction bool `validate:"omitempty"`
-		// Action string `validate:"required,oneof=Close_Connection Redirect Local_Response"`
 	}
 
 	PoliciesHTTPActionSendResponse struct {

--- a/v1/edgeloadbalancer/policies_http_types_actions.go
+++ b/v1/edgeloadbalancer/policies_http_types_actions.go
@@ -9,7 +9,11 @@
 
 package edgeloadbalancer
 
-import govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+import (
+	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/internal/utils"
+)
 
 // * Action
 
@@ -64,21 +68,31 @@ type (
 		KeepQuery bool `validate:"omitempty"`
 	}
 
-	// PoliciesHTTPActionRedirectToHTTPS struct {
-	// 	// The port must be between 1 to 65535
-	// 	Port int
-	// }
-
 	PoliciesHTTPActionRateLimit struct {
-		// Maximum number of requests per period allowed 1 to 1000000000
-		Count int `validate:"required"`
+		//
+		// number of requests per period allowed 1 to 1000000000
+		// Default is 1000 requests
+		// 1 request is the minimum
+		// 1000000000 requests is the maximum
+		Count int `validate:"default=1000,min=1,max=1000000000"`
+		//
 		// Time period in seconds for the rate limit 1 to 1000000000
-		Period int `validate:"required"`
-		// Action to take when the rate limit is exceeded
+		// Default is 60 seconds
+		// 1 second is the minimum period
+		// 1000000000 seconds is the maximum period
+		Period int `validate:"default=60,min=1,max=1000000000"`
+		//
+		// Action to do an HTTP redirect when the rate limit is exceeded
+		// It can't be configured in combination with other actions below
 		RedirectAction *PoliciesHTTPActionRedirect `validate:"omitempty"`
-		// Action to take when the rate limit is exceeded
-		CloseConnectionAction string `validate:"omitempty"`
-		// Action to take when the rate limit is exceeded
+		//
+		// Action to close the connection HTTP when the rate limit is exceeded
+		// The network connection is closed (no error http return).
+		// It can't be configured in combination with other actions
+		CloseConnectionAction *bool `validate:"omitempty"`
+		//
+		// You can use this action to send a custom response to the client when the rate limit is exceeded.
+		// It can't be configured in combination with other actions
 		LocalResponseAction *PoliciesHTTPActionSendResponse `validate:"omitempty"`
 	}
 
@@ -87,8 +101,8 @@ type (
 		StatusCode int `validate:"required,oneof=200 204 403 404 429 501"`
 		// Content type of the response
 		ContentType string `validate:"required,oneof=application/json text/html text/plain"`
-		// Content of the response
-		Content string `validate:"required"`
+		// Content of the response - base64 encoded string
+		Content string `validate:"required,base64"`
 	}
 )
 
@@ -117,6 +131,8 @@ func (p *PoliciesHTTPActionHeaderRewrite) toVCD() *govcdtypes.AlbVsHttpRequestRu
 		Value:  p.Value,
 	}
 }
+
+// * Helpers to convert PoliciesHTTPActionHeadersRewrite to and from vCD types
 
 func (PoliciesHTTPActionHeadersRewrite) fromVCD(action []*govcdtypes.AlbVsHttpRequestRuleHeaderActions) PoliciesHTTPActionHeadersRewrite {
 	var headers []*PoliciesHTTPActionHeaderRewrite
@@ -191,5 +207,77 @@ func (p *PoliciesHTTPActionLocationRewrite) toVCD() *govcdtypes.AlbVsHttpRespRul
 		Port:      p.Port,
 		Path:      p.Path,
 		KeepQuery: p.KeepQuery,
+	}
+}
+
+// * Helpers to convert PoliciesHTTPActionRateLimit to and from vCD types
+
+func (PoliciesHTTPActionRateLimit) fromVCD(action *govcdtypes.AlbVsHttpSecurityRuleRateLimitAction) *PoliciesHTTPActionRateLimit {
+	if action == nil {
+		return nil
+	}
+	return &PoliciesHTTPActionRateLimit{
+		Count:  action.Count,
+		Period: action.Period,
+		RedirectAction: func() *PoliciesHTTPActionRedirect {
+			if action.RedirectAction != nil {
+				return (&PoliciesHTTPActionRedirect{}).fromVCD(action.RedirectAction)
+			}
+			return nil
+		}(),
+		LocalResponseAction: func() *PoliciesHTTPActionSendResponse {
+			if action.LocalResponseAction != nil {
+				return (&PoliciesHTTPActionSendResponse{}).fromVCD(action.LocalResponseAction)
+			}
+			return nil
+		}(),
+		CloseConnectionAction: func() *bool {
+			if action.CloseConnectionAction == string(PoliciesHTTPConnectionActionCLOSE) {
+				return utils.ToPTR(true)
+			}
+			return nil
+		}(),
+	}
+}
+
+func (p *PoliciesHTTPActionRateLimit) toVCD() *govcdtypes.AlbVsHttpSecurityRuleRateLimitAction {
+	if p == nil {
+		return nil
+	}
+	return &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
+		Count:  p.Count,
+		Period: p.Period,
+		CloseConnectionAction: func() string {
+			if p.CloseConnectionAction != nil && *p.CloseConnectionAction {
+				return string(PoliciesHTTPConnectionActionCLOSE)
+			}
+			return ""
+		}(),
+		RedirectAction:      p.RedirectAction.toVCD(),
+		LocalResponseAction: p.LocalResponseAction.toVCD(),
+	}
+}
+
+// * Helpers to convert PoliciesHTTPActionSendResponse to and from vCD types
+
+func (PoliciesHTTPActionSendResponse) fromVCD(action *govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction) *PoliciesHTTPActionSendResponse {
+	if action == nil {
+		return nil
+	}
+	return &PoliciesHTTPActionSendResponse{
+		StatusCode:  action.StatusCode,
+		ContentType: action.ContentType,
+		Content:     action.Content,
+	}
+}
+
+func (p *PoliciesHTTPActionSendResponse) toVCD() *govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction {
+	if p == nil {
+		return nil
+	}
+	return &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
+		Content:     p.Content,
+		ContentType: p.ContentType,
+		StatusCode:  p.StatusCode,
 	}
 }

--- a/v1/edgeloadbalancer/policies_http_types_matches.go
+++ b/v1/edgeloadbalancer/policies_http_types_matches.go
@@ -214,6 +214,8 @@ func (p *PoliciesHTTPHeaderMatch) toVCD() *govcdtypes.AlbVsHttpRequestRuleHeader
 	}
 }
 
+// * Helpers to convert PoliciesHTTPHeadersMatch to and from vCD types
+
 func (PoliciesHTTPHeadersMatch) fromVCD(match []govcdtypes.AlbVsHttpRequestRuleHeaderMatch) PoliciesHTTPHeadersMatch {
 	var headers []PoliciesHTTPHeaderMatch
 	for _, h := range match {

--- a/v1/edgeloadbalancer/policies_http_types_matches.go
+++ b/v1/edgeloadbalancer/policies_http_types_matches.go
@@ -16,6 +16,9 @@ type (
 	PoliciesHTTPMethod                    string
 	PoliciesHTTPMatchCriteriaCriteria     string
 	PoliciesHTTPActionHeaderRewriteAction string
+	// PoliciesHTTPConnectionAction specifies the action to be taken on the connection.
+	// var PoliciesHTTPConnectionAction and PoliciesHTTPConnectionActionString are defined to get the list of valid values.
+	PoliciesHTTPConnectionAction string
 )
 
 type (

--- a/v1/edgeloadbalancer/virtual_service_types.go
+++ b/v1/edgeloadbalancer/virtual_service_types.go
@@ -28,6 +28,8 @@ type (
 		UpdateHttpRequestRules(config *govcdtypes.AlbVsHttpRequestRules) (*govcdtypes.AlbVsHttpRequestRules, error)
 		GetAllHttpResponseRules(queryParameters url.Values) ([]*govcdtypes.AlbVsHttpResponseRule, error)
 		UpdateHttpResponseRules(config *govcdtypes.AlbVsHttpResponseRules) (*govcdtypes.AlbVsHttpResponseRules, error)
+		GetAllHttpSecurityRules(queryParameters url.Values) ([]*govcdtypes.AlbVsHttpSecurityRule, error)
+		UpdateHttpSecurityRules(config *govcdtypes.AlbVsHttpSecurityRules) (*govcdtypes.AlbVsHttpSecurityRules, error)
 	}
 
 	VirtualServiceModel struct {


### PR DESCRIPTION
This pull request introduces methods for managing HTTP security policies for edge gateway load balancers, along with associated data models and helper functions. It also includes a minor code comment update to suppress a linter warning. Below is a summary of the most important changes, grouped by theme.

### New Features: HTTP Security Policies for Edge Gateway Load Balancers
* Added methods `GetPoliciesHTTPSecurity`, `UpdatePoliciesHTTPSecurity`, and `DeletePoliciesHTTPSecurity` to handle HTTP security policies in the `v1/edgeloadbalancer/client.go` interface. These methods allow retrieving, updating, and deleting HTTP security policies.
* Introduced the `PoliciesHTTPSecurityModel` and related types in `v1/edgeloadbalancer/policies_http_security_types.go` to define the structure of HTTP security policies, including validation rules and conversion helpers to/from vCD types.
* Implemented the logic for managing HTTP security policies in `v1/edgeloadbalancer/policies_http_security.go`, including validation, data retrieval, and updates via virtual service clients.
* Updated the `fakeVirtualServiceClient` interface in `v1/edgeloadbalancer/virtual_service_types.go` to include methods for handling HTTP security rules (`GetAllHttpSecurityRules` and `UpdateHttpSecurityRules`).

### Minor Code Updates
* Suppressed a linter warning in the `GetEndAddress` method of `v1/edgegw.go` by adding a `//nolint:gosec` comment.

### Documentation and Release Notes
* Added release notes in `.changelog/240.txt` to document the new HTTP security policy management feature for edge gateway load balancers.