### PR TITLE
chore: Update ref URL to new wiki cloudavenue

### DIFF
--- a/.changelog/279.txt
+++ b/.changelog/279.txt
@@ -1,0 +1,4 @@
+```release-note:documentation
+chore: Updated all source links to the new Cloud Avenue documentation portal.
+```
+

--- a/v1/edgegw_types.go
+++ b/v1/edgegw_types.go
@@ -48,7 +48,7 @@ type (
 )
 
 var (
-	// Source : https://wiki.cloudavenue.orange-business.com/wiki/Network
+	// Source : https://cloud.orange-business.com/en/offres/infrastructure-iaas/cloud-avenue/wiki-cloud-avenue/services/network/
 	EdgeGatewayAllowedBandwidth = map[ClassService]struct {
 		T0TotalBandwidth   int
 		T1AllowedBandwidth []int

--- a/v1/infrapi/rules/vdc_rules.go
+++ b/v1/infrapi/rules/vdc_rules.go
@@ -897,7 +897,7 @@ func (r Rule) GetRuleDetails() string {
 func GetRulesDetails() string {
 	x := ""
 	x += "## Rules\n"
-	x += "More information about rules can be found [here](https://wiki.cloudavenue.orange-business.com/wiki/Virtual_Datacenter)."
+	x += "More information about rules can be found [here](https://cloud.orange-business.com/en/offres/infrastructure-iaas/cloud-avenue/wiki-cloud-avenue/services/virtual-datacenter/virtual-datacenter/)."
 	x += "All fields with a ** are editable.\n\n"
 	for _, sc := range ALLServiceClasses {
 		r, err := GetRuleByServiceClass(sc)
@@ -944,7 +944,7 @@ func (r Rule) GetStorageProfileDetails() string {
 func GetStorageProfilesDetails() string {
 	x := ""
 	x += "## Storage Profiles\n"
-	x += "More information about storage profiles can be found [here](https://wiki.cloudavenue.orange-business.com/wiki/Storage)."
+	x += "More information about storage profiles can be found [here](https://cloud.orange-business.com/en/offres/infrastructure-iaas/cloud-avenue/wiki-cloud-avenue/services/block-storage/)."
 	x += "All fields with a ** are editable.\n\n"
 	for _, sc := range ALLServiceClasses {
 		r, err := GetRuleByServiceClass(sc)


### PR DESCRIPTION
This pull request updates documentation links across multiple files to point to the new Cloud Avenue documentation portal. The changes ensure that all references are aligned with the updated portal structure.

### Documentation Updates:

* [`.changelog/279.txt`](diffhunk://#diff-e41eb393d74407dd7f0a3ba1f4f9e74047588e5d621ed2044b3628b429e8523eR1-R4): Added a release note documenting the update of all source links to the new Cloud Avenue documentation portal.

* [`v1/edgegw_types.go`](diffhunk://#diff-7a244aa07ef0f00ccb7f48cae71b20e9eee25d6bc835d24866abe47b80e420aaL51-R51): Updated the `EdgeGatewayAllowedBandwidth` source link to the new Cloud Avenue documentation portal.

* `v1/infrapi/rules/vdc_rules.go`:
  - [`GetRuleDetails()`](diffhunk://#diff-129faaac76a182fcf52ed0f65820633161a4bb910a1fc006b148d0a14ada4c3dL900-R900): Updated the link for more information about rules to the new Cloud Avenue documentation portal.
  - [`GetStorageProfileDetails()`](diffhunk://#diff-129faaac76a182fcf52ed0f65820633161a4bb910a1fc006b148d0a14ada4c3dL947-R947): Updated the link for more information about storage profiles to the new Cloud Avenue documentation portal.