### PR TITLE
fix: error validation on create user Local and SAML

### DIFF
--- a/v1/iam/user.go
+++ b/v1/iam/user.go
@@ -37,7 +37,7 @@ func (c *Client) CreateLocalUser(user LocalUser) (*UserClient, error) {
 //   - *User: Pointer to the created User object.
 //   - error: Error, if any occurred during the creation process.
 func (c *Client) CreateSAMLUser(user SAMLUser) (*UserClient, error) {
-	userCreated, err := c.createGenericUser(user)
+	userCreated, err := c.createGenericUser(&user)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/iam/user_types.go
+++ b/v1/iam/user_types.go
@@ -146,10 +146,10 @@ func toGoVCDTypeUser(user any, roleReference *govcdtypes.Reference) *govcdtypes.
 	// Switch name of the user struct to set specific fields
 	// No default case because only LocalUser and SAMLUser are extra fields
 	switch v := user.(type) {
-	case LocalUser:
+	case *LocalUser:
 		u.Password = v.Password
 		u.ProviderType = govcd.OrgUserProviderIntegrated
-	case SAMLUser:
+	case *SAMLUser:
 		u.ProviderType = govcd.OrgUserProviderSAML
 		u.IsExternal = true
 	}


### PR DESCRIPTION
This pull request updates how user objects are handled when creating users and converting user types, ensuring that pointers to user structs are consistently used. This change improves type safety and ensures that fields are set correctly.

Type handling improvements:

* Updated the `CreateSAMLUser` function in `user.go` to pass a pointer to the `SAMLUser` struct when calling `createGenericUser`, ensuring consistency with how user objects are handled.
* Modified the `toGoVCDTypeUser` function in `user_types.go` to switch on pointers to `LocalUser` and `SAMLUser` structs, instead of values, which aligns with the changes in user creation and avoids potential issues with field access.