### PR TITLE
feat(api): migrate from Infrapi to Cerberus API

### DIFF
--- a/.changelog/298.txt
+++ b/.changelog/298.txt
@@ -1,0 +1,11 @@
+```release-note:note
+Updated the default VCD API version to 39.1 for better compatibility with the latest vCloud Director features.
+```
+
+```release-note:breaking-change
+Migrated authentication to use the new token endpoint, which includes changes in the token response structure. This release introduces a end of life of the legacy authentication method at 01/10/2026, and may require updates to bump the SDK version and adjust authentication handling in existing code.
+```
+
+```release-note:breaking-change
+Updated organization retrieval to use GetOrgByName and GetAdminOrgByName methods, which may affect existing code that relies on organization ID formats.
+```

--- a/internal/endpoints/edgegateway.go
+++ b/internal/endpoints/edgegateway.go
@@ -11,14 +11,14 @@ package endpoints
 
 // List of API endpoints.
 const (
-	EdgeGatewayCreateFromVDC      = "/api/customers/v2.0/vdcs/{vdc-name}/edges"
-	EdgeGatewayCreateFromVDCGroup = "/api/customers/v2.0/vdc-groups/{vdc-group-name}/edges"
-	EdgeGatewayGet                = "/api/customers/v2.0/edges/{edge-id}"
-	EdgeGatewayList               = "/api/customers/v2.0/edges"
+	EdgeGatewayCreateFromVDC      = "/infrapicustomerproxy/v2.0/vdcs/{vdc-name}/edges"
+	EdgeGatewayCreateFromVDCGroup = "/infrapicustomerproxy/v2.0/vdc-groups/{vdc-group-name}/edges"
+	EdgeGatewayGet                = "/infrapicustomerproxy/v2.0/edges/{edge-id}"
+	EdgeGatewayList               = "/infrapicustomerproxy/v2.0/edges"
 	EdgeGatewayDelete             = EdgeGatewayGet
 	EdgeGatewayUpdate             = EdgeGatewayGet
 
-	NetworkServiceGet    = "/api/customers/v2.0/network"
-	NetworkServiceCreate = "/api/customers/v2.0/services"
-	NetworkServiceDelete = "/api/customers/v2.0/services/{service-id}"
+	NetworkServiceGet    = "/infrapicustomerproxy/v2.0/network"
+	NetworkServiceCreate = "/infrapicustomerproxy/v2.0/services"
+	NetworkServiceDelete = "/infrapicustomerproxy/v2.0/services/{service-id}"
 )

--- a/internal/endpoints/job.go
+++ b/internal/endpoints/job.go
@@ -10,5 +10,5 @@
 package endpoints
 
 const (
-	JobStatusGet = "/api/customers/v1.0/jobs/{job-id}"
+	JobStatusGet = "/infrapicustomerproxy/v1.0/jobs/{job-id}"
 )

--- a/pkg/clients/cloudavenue/cloudavenue.go
+++ b/pkg/clients/cloudavenue/cloudavenue.go
@@ -28,7 +28,7 @@ import (
 
 // DefaultVCDAPIVersion is the default VCD API version used for VMware client.
 // This is kept for backward compatibility with the VMware govcd client.
-const DefaultVCDAPIVersion = "37.2"
+const DefaultVCDAPIVersion = "39.1"
 
 var (
 	_ model.ClientOpts = (*Opts)(nil)

--- a/pkg/clients/cloudavenue/cloudavenue.go
+++ b/pkg/clients/cloudavenue/cloudavenue.go
@@ -110,7 +110,7 @@ func Init(opts *Opts) (err error) {
 	c.token.endpoint = opts.URL
 	c.token.debug = opts.Debug
 
-	return
+	return err
 }
 
 type Client struct {

--- a/pkg/clients/cloudavenue/cloudavenue.go
+++ b/pkg/clients/cloudavenue/cloudavenue.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sethvargo/go-envconfig"
-	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -27,21 +26,24 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/errors"
 )
 
+// DefaultVCDAPIVersion is the default VCD API version used for VMware client.
+// This is kept for backward compatibility with the VMware govcd client.
+const DefaultVCDAPIVersion = "37.2"
+
 var (
 	_ model.ClientOpts = (*Opts)(nil)
 	c                  = &internalClient{}
 )
 
-// Opts - Is a struct that contains the options for the vmware client.
+// Opts - Is a struct that contains the options for the cloudavenue client.
 type Opts struct {
-	URL        string `env:"URL,overwrite"`      // Computed from Org if not provided
-	Username   string `env:"USERNAME,overwrite"` // Required
-	Password   string `env:"PASSWORD,overwrite"` // Required
-	Org        string `env:"ORG,overwrite"`      // Required
-	VDC        string `env:"VDC,overwrite"`
-	Debug      bool   `env:"DEBUG,overwrite"`
-	VCDVersion string `env:"VCD_VERSION,overwrite,default=37.2"`
-	Dev        bool   `env:"DEV,overwrite"` // Only for development
+	URL      string `env:"URL,overwrite"`      // Computed from Org if not provided
+	Username string `env:"USERNAME,overwrite"` // Required (used as client_id for OAuth2)
+	Password string `env:"PASSWORD,overwrite"` // Required (used as client_secret for OAuth2)
+	Org      string `env:"ORG,overwrite"`      // Required (used as scope tenant:{org} for OAuth2)
+	VDC      string `env:"VDC,overwrite"`
+	Debug    bool   `env:"DEBUG,overwrite"`
+	Dev      bool   `env:"DEV,overwrite"` // Only for development
 }
 
 func (o *Opts) Validate() error {
@@ -88,15 +90,6 @@ func (o *Opts) Validate() error {
 		}
 	}
 
-	// Check if VDCVersion is not empty and semver format
-	if o.VCDVersion == "" {
-		return fmt.Errorf("the vcd version is %w", errors.ErrEmpty)
-	}
-
-	if semver.IsValid(o.VCDVersion) {
-		return fmt.Errorf("the vcd version is %w", errors.ErrInvalidFormat)
-	}
-
 	return nil
 }
 
@@ -104,20 +97,18 @@ type internalClient struct {
 	token token
 }
 
-// Init - Initializes the client.
+// Init - Initializes the client with OAuth2 credentials.
 func Init(opts *Opts) (err error) {
 	if err := opts.Validate(); err != nil {
 		return err
 	}
 
-	c.token.username = opts.Username
-	c.token.password = opts.Password
+	c.token.clientID = opts.Username
+	c.token.clientSecret = opts.Password
 	c.token.org = opts.Org
 	c.token.vdc = opts.VDC
 	c.token.endpoint = opts.URL
 	c.token.debug = opts.Debug
-	c.token.vcdVersion = opts.VCDVersion
-	c.token.endpoint = opts.URL
 
 	return
 }
@@ -171,11 +162,11 @@ func New() (*Client, error) {
 	cache.Vmware = govcd.NewVCDClient(
 		*vmwareURL,
 		false,
-		govcd.WithAPIVersion(c.token.GetVCDVersion()),
+		govcd.WithAPIVersion(DefaultVCDAPIVersion),
 	)
 
-	if err := cache.Vmware.SetToken(c.token.GetOrganization(), govcd.AuthorizationHeader, c.token.GetToken()); err != nil {
-		return nil, fmt.Errorf("%w : %w", errors.ErrConfigureVmwareClient, err)
+	if err := cache.Vmware.Authenticate(c.token.clientID, c.token.clientSecret, c.token.org); err != nil {
+		return nil, fmt.Errorf("%s : %w", "Failed to authenticate vmware client", err)
 	}
 
 	// goroutine to get the org from client
@@ -188,22 +179,26 @@ func New() (*Client, error) {
 		return cache.getAdminOrg()
 	})
 
-	// Setup InfrAPI client
+	// Setup Cerberus API client (InfrAPI proxy)
 	wg.Go(func() error {
 		cache.Client = resty.New().
 			SetDebug(c.token.debug).
-			SetHeader("Accept", "application/json;version="+c.token.vcdVersion).
-			SetBaseURL(c.token.GetEndpoint()).
-			SetAuthToken(c.token.GetToken())
+			// SetHeader("Content-Type", "application/json").
+			SetHeader("Accept", "application/json").
+			SetBaseURL(consoles.CerberusAPIEndpoint).
+			SetAuthScheme("Bearer").
+			SetAuthToken(c.token.GetToken()).
+			SetHeader("User-Agent", "Cloudavenue-SDK-v1")
+
 		return nil
 	})
 
 	return cache, wg.Wait()
 }
 
-// GetUsername - Returns the username.
+// GetUsername - Returns the username (client_id).
 func (v *Client) GetUsername() string {
-	return c.token.username
+	return c.token.clientID
 }
 
 // GetOrganization - Returns the organization.
@@ -241,9 +236,11 @@ func MockClient() *Client {
 	if cache == nil {
 		cache = &Client{
 			Client: resty.New().
-				SetHeader("Accept", "application/json;version="+c.token.vcdVersion).
+				SetHeader("Content-Type", "application/json").
+				SetHeader("Accept", "application/json").
 				SetBaseURL("http://local.test").
-				SetAuthToken(""),
+				SetAuthScheme("Bearer").
+				SetAuthToken("mock-token"),
 		}
 	}
 

--- a/pkg/clients/cloudavenue/org.go
+++ b/pkg/clients/cloudavenue/org.go
@@ -11,22 +11,12 @@ package clientcloudavenue
 
 // getOrg returns the org object from the vCloud Director API.
 func (v *Client) getOrg() (err error) {
-	// if !urn.IsOrg(v.GetOrganizationID()) {
-	// 	return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
-	// }
-
 	v.Org, err = v.Vmware.GetOrgByName(v.GetOrganization())
-
 	return err
 }
 
 // getAdminOrg returns the admin org object from the vCloud Director API.
 func (v *Client) getAdminOrg() (err error) {
-	// if !urn.IsOrg(v.GetOrganizationID()) {
-	// 	return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
-	// }
-
 	v.AdminOrg, err = v.Vmware.GetAdminOrgByName(v.GetOrganization())
-
 	return err
 }

--- a/pkg/clients/cloudavenue/org.go
+++ b/pkg/clients/cloudavenue/org.go
@@ -9,17 +9,11 @@
 
 package clientcloudavenue
 
-import (
-	"fmt"
-
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
-)
-
 // getOrg returns the org object from the vCloud Director API.
 func (v *Client) getOrg() (err error) {
-	if !urn.IsOrg(v.GetOrganizationID()) {
-		return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
-	}
+	// if !urn.IsOrg(v.GetOrganizationID()) {
+	// 	return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
+	// }
 
 	v.Org, err = v.Vmware.GetOrgByName(v.GetOrganization())
 
@@ -28,9 +22,9 @@ func (v *Client) getOrg() (err error) {
 
 // getAdminOrg returns the admin org object from the vCloud Director API.
 func (v *Client) getAdminOrg() (err error) {
-	if !urn.IsOrg(v.GetOrganizationID()) {
-		return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
-	}
+	// if !urn.IsOrg(v.GetOrganizationID()) {
+	// 	return fmt.Errorf("invalid organization ID format: %s", v.GetOrganizationID())
+	// }
 
 	v.AdminOrg, err = v.Vmware.GetAdminOrgByName(v.GetOrganization())
 

--- a/pkg/clients/cloudavenue/token.go
+++ b/pkg/clients/cloudavenue/token.go
@@ -17,30 +17,30 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
+// token holds the OAuth2 authentication state for Cerberus API.
 type token struct {
-	baererToken string
+	// OAuth2 token fields
+	accessToken string
+	tokenType   string // "Bearer"
 	expiresAt   time.Time
 
-	username   string
-	password   string
-	org        string
-	orgID      string
-	vdc        string
-	vcdVersion string
+	// Credentials
+	clientID     string // username
+	clientSecret string // password
+	org          string
 
+	// Legacy fields maintained for compatibility
+	orgID string
+	vdc   string
+
+	// Connection settings
 	endpoint string
-
-	debug bool
+	debug    bool
 }
 
 // GetOrganization - Returns the organization.
 func (t *token) GetOrganization() string {
 	return t.org
-}
-
-// GetVCDVersion - Returns the VCD version.
-func (t *token) GetVCDVersion() string {
-	return t.vcdVersion
 }
 
 // GetEndpoint - Returns the API endpoint.
@@ -55,76 +55,123 @@ func (t *token) GetEndpointURL() url.URL {
 }
 
 // IsExpired - Returns true if the token is expired.
+// Includes a 30-second buffer to prevent edge cases.
 func (t *token) IsExpired() bool {
-	return t.expiresAt.Before(time.Now())
+	return t.expiresAt.Add(-30 * time.Second).Before(time.Now())
 }
 
 // IsSet - Returns true if the token is set.
 func (t *token) IsSet() bool {
-	return t.baererToken != ""
+	return t.accessToken != ""
 }
 
-// GetToken - Returns the token.
+// GetToken - Returns the access token.
 func (t *token) GetToken() string {
-	return t.baererToken
+	return t.accessToken
+}
+
+// GetTokenType - Returns the token type (Bearer).
+func (t *token) GetTokenType() string {
+	return t.tokenType
 }
 
 // GetOrgID - Returns the organization ID.
+// Note: OrgID is no longer available directly from Cerberus auth response.
+// It must be fetched separately via /infrapicustomerproxy/v2.0/configurations.
 func (t *token) GetOrgID() string {
 	return t.orgID
 }
 
-// RefreshToken - Refreshes the token.
+// SetOrgID - Sets the organization ID.
+// Used to set OrgID after fetching it from configurations endpoint.
+func (t *token) SetOrgID(orgID string) {
+	t.orgID = orgID
+}
+
+// RefreshToken - Authenticates to Cerberus API using OAuth2 Client Credentials.
+// POST /auth/v1/user/token
+// Content-Type: application/x-www-form-urlencoded
+// Body: grant_type=client_credentials&client_id={username}&client_secret={password}&scope=tenant:{org}
 func (t *token) RefreshToken() error {
-	if !t.IsSet() || t.IsExpired() {
-		c := resty.New().SetBaseURL(t.endpoint)
-
-		r, err := c.R().
-			SetDebug(t.debug).
-			// SetHeader("Content-Type", "application/x-www-form-url-encoded").
-			SetHeader("Accept", "application/json;version="+t.vcdVersion).
-			SetResult(&authTokenResponse{}).
-			SetError(&APIErrorResponse{}).
-			SetBasicAuth(t.username+"@"+t.org, t.password).
-			Post("/cloudapi/1.0.0/sessions")
-		if err != nil {
-			return err
-		}
-
-		if r.IsError() {
-			return fmt.Errorf("authentification failed : HTTPCode:%s - %s ", r.Status(), r.Error().(*APIErrorResponse).FormatError())
-		}
-		// Set the token
-		t.baererToken = r.Header().Get("X-VMWARE-VCLOUD-ACCESS-TOKEN")
-
-		// Calculate the expiration date
-		refreshedToken := r.Result().(*authTokenResponse)
-		// Set OrganizationID
-		t.orgID = refreshedToken.Org.ID
-		t.expiresAt = time.Now().Add(time.Duration(refreshedToken.SessionIdleTimeoutMinutes) * time.Minute)
+	if t.IsSet() && !t.IsExpired() {
+		return nil
 	}
+
+	c := resty.New().SetBaseURL("https://api1.cloudavenue.orange-business.com")
+
+	r, err := c.R().
+		SetDebug(t.debug).
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetHeader("Accept", "application/json").
+		SetFormData(map[string]string{
+			"grant_type":    "client_credentials",
+			"client_id":     t.clientID,
+			"client_secret": t.clientSecret,
+			"scope":         "tenant:" + t.org,
+		}).
+		SetResult(&cerberusAuthResponse{}).
+		SetError(&CerberusErrorResponse{}).
+		Post("/auth/v1/user/token")
+	if err != nil {
+		return fmt.Errorf("authentication request failed: %w", err)
+	}
+
+	if r.IsError() {
+		cerberusErr, ok := r.Error().(*CerberusErrorResponse)
+		if ok && cerberusErr != nil {
+			return fmt.Errorf("authentication failed: HTTPCode:%s - %s", r.Status(), cerberusErr.FormatError())
+		}
+		return fmt.Errorf("authentication failed: HTTPCode:%s", r.Status())
+	}
+
+	// Parse the OAuth2 response
+	authResp, ok := r.Result().(*cerberusAuthResponse)
+	if !ok || authResp == nil {
+		return fmt.Errorf("authentication failed: invalid response format")
+	}
+
+	if authResp.AccessToken == "" {
+		return fmt.Errorf("authentication failed: empty access token received")
+	}
+
+	// Set the token
+	t.accessToken = authResp.AccessToken
+	t.tokenType = authResp.Type
+	if t.tokenType == "" {
+		t.tokenType = "Bearer" // Default to Bearer if not specified
+	}
+
+	// Calculate the expiration date (expires_in is in seconds)
+	t.expiresAt = time.Now().Add(time.Duration(authResp.ExpiresIn) * time.Second)
+
 	return nil
 }
 
-type authTokenResponse struct {
-	ID   string `json:"id"`
-	User struct {
-		Name string `json:"name"`
-		ID   string `json:"id"`
-	} `json:"user"`
-	Org struct {
-		Name string `json:"name"`
-		ID   string `json:"id"`
-	} `json:"org"`
-	Location string   `json:"location"`
-	Roles    []string `json:"roles"`
-	RoleRefs []struct {
-		Name string `json:"name"`
-		ID   string `json:"id"`
-	} `json:"roleRefs"`
-	SessionIdleTimeoutMinutes int `json:"sessionIdleTimeoutMinutes"`
+// cerberusAuthResponse - OAuth2 token response from Cerberus API.
+// Response from POST /auth/v1/user/token
+type cerberusAuthResponse struct {
+	AccessToken string `json:"access_token"`
+	Type        string `json:"type"`
+	ExpiresIn   int    `json:"expires_in"` // seconds
 }
 
+// CerberusErrorResponse - Error response from Cerberus API.
+type CerberusErrorResponse struct {
+	Code        int    `json:"code"`
+	Message     string `json:"message"`
+	Description string `json:"description,omitempty"`
+}
+
+// FormatError - Formats the Cerberus error.
+func (e *CerberusErrorResponse) FormatError() string {
+	if e.Description != "" {
+		return fmt.Sprintf("ErrorCode:%d - Message:%s - Description:%s", e.Code, e.Message, e.Description)
+	}
+	return fmt.Sprintf("ErrorCode:%d - Message:%s", e.Code, e.Message)
+}
+
+// APIErrorResponse - Generic API error response.
+// Kept for backward compatibility with existing code.
 type APIErrorResponse struct {
 	Code    string `json:"code"`
 	Reason  string `json:"reason"`

--- a/pkg/clients/cloudavenue/token.go
+++ b/pkg/clients/cloudavenue/token.go
@@ -151,7 +151,7 @@ func (t *token) RefreshToken() error {
 // Response from POST /auth/v1/user/token
 type cerberusAuthResponse struct {
 	AccessToken string `json:"access_token"`
-	Type        string `json:"type"`
+	Type        string `json:"token_type"`
 	ExpiresIn   int    `json:"expires_in"` // seconds
 }
 

--- a/pkg/clients/consoles/consoles.go
+++ b/pkg/clients/consoles/consoles.go
@@ -244,9 +244,3 @@ func (c Console) GetSiteID() Console {
 func (c Console) GetURL() string {
 	return consoles[c].URL
 }
-
-// GetLegacyURL - Returns the legacy console URL (before Cerberus migration).
-// This is kept for reference and backward compatibility.
-func (c Console) GetLegacyURL() string {
-	return consoles[c].URL
-}

--- a/pkg/clients/consoles/consoles.go
+++ b/pkg/clients/consoles/consoles.go
@@ -15,6 +15,10 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/errors"
 )
 
+// CerberusAPIEndpoint is the unified API endpoint for all consoles.
+// With the Cerberus migration, all organizations now use a single API endpoint.
+const CerberusAPIEndpoint = "https://api1.cloudavenue.orange-business.com"
+
 type (
 	Console      string
 	LocationCode string
@@ -23,7 +27,7 @@ type (
 		SiteName            string
 		LocationCode        LocationCode
 		SiteID              Console
-		URL                 string
+		URL                 string // Legacy URL (kept for reference)
 		Services            Services
 		OrganizationPattern *regexp.Regexp
 	}
@@ -59,7 +63,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console Externe VDR",
 		LocationCode:        LocationVDR,
 		SiteID:              Console1,
-		URL:                 "https://console1.cloudavenue.orange-business.com",
+		URL:                 "https://console1.cloudavenue.orange-business.com", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav01ev01ocb\d{7}$`),
 		Services: Services{
 			S3: Service{
@@ -76,7 +80,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console Interne VDR",
 		LocationCode:        LocationVDR,
 		SiteID:              Console2,
-		URL:                 "https://console2.cloudavenue.orange-business.com",
+		URL:                 "https://console2.cloudavenue.orange-business.com", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav01iv02ocb\d{7}$`),
 		Services: Services{
 			S3: Service{
@@ -94,7 +98,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console Externe CHA",
 		LocationCode:        LocationCHR,
 		SiteID:              Console4,
-		URL:                 "https://console4.cloudavenue.orange-business.com",
+		URL:                 "https://console4.cloudavenue.orange-business.com", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav02ev04ocb\d{7}$`),
 		Services: Services{
 			Netbackup: Service{
@@ -107,7 +111,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console Interne CHA",
 		LocationCode:        LocationCHR,
 		SiteID:              Console5,
-		URL:                 "https://console5.cloudavenue-cha.itn.intraorange",
+		URL:                 "https://console5.cloudavenue-cha.itn.intraorange", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav02iv05ocb\d{7}$`),
 		Services: Services{
 			Netbackup: Service{
@@ -121,7 +125,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console specific VDR",
 		LocationCode:        LocationVDR,
 		SiteID:              Console7,
-		URL:                 "https://console7.cloudavenue-vdr.itn.intraorange",
+		URL:                 "https://console7.cloudavenue-vdr.itn.intraorange", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav01iv07ocb\d{7}$`),
 		Services: Services{
 			Netbackup: Service{
@@ -134,7 +138,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console specific VDR",
 		LocationCode:        LocationVDR,
 		SiteID:              Console8,
-		URL:                 "https://console8.cloudavenue-vdr.itn.intraorange",
+		URL:                 "https://console8.cloudavenue-vdr.itn.intraorange", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav01iv08ocb\d{7}$`),
 		Services: Services{
 			Netbackup: Service{
@@ -148,7 +152,7 @@ var consoles = map[Console]console{
 		SiteName:            "Console VCOD",
 		LocationCode:        LocationVDRCHA,
 		SiteID:              Console9,
-		URL:                 "https://console9.cloudavenue.orange-business.com",
+		URL:                 "https://console9.cloudavenue.orange-business.com", // Legacy
 		OrganizationPattern: regexp.MustCompile(`^cav0[0-2]{1}vv09ocb\d{7}$`),
 		Services: Services{
 			Netbackup: Service{
@@ -171,7 +175,9 @@ func FindBySiteID(siteID string) (Console, bool) {
 }
 
 // FindByURL - Returns the console by its URL.
+// This function now checks against the legacy URL for backward compatibility.
 func FindByURL(url string) (Console, bool) {
+	// Legacy lookup by old console URLs
 	for c, console := range consoles {
 		if console.URL == url {
 			return c, true
@@ -233,7 +239,14 @@ func (c Console) GetSiteID() Console {
 	return consoles[c].SiteID
 }
 
-// GetURL - Returns the URL.
+// GetURL - Returns the Cerberus API endpoint.
+// With the Cerberus migration, all consoles now use a single unified endpoint.
 func (c Console) GetURL() string {
+	return consoles[c].URL
+}
+
+// GetLegacyURL - Returns the legacy console URL (before Cerberus migration).
+// This is kept for reference and backward compatibility.
+func (c Console) GetLegacyURL() string {
 	return consoles[c].URL
 }

--- a/v1/cloudavenue_bms.go
+++ b/v1/cloudavenue_bms.go
@@ -60,7 +60,7 @@ func (v *BMS) List() (response *[]BMS, err error) {
 	r, err := c.R().
 		SetResult([]BMS{}). //- because the response is a slice of struct
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/bms")
+		Get("/infrapicustomerproxy/v2.0/bms")
 	if err != nil {
 		return
 	}

--- a/v1/cloudavenue_bms.go
+++ b/v1/cloudavenue_bms.go
@@ -54,7 +54,7 @@ type (
 func (v *BMS) List() (response *[]BMS, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	r, err := c.R().
@@ -62,7 +62,7 @@ func (v *BMS) List() (response *[]BMS, err error) {
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		Get("/infrapicustomerproxy/v2.0/bms")
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if r.IsError() {

--- a/v1/cloudavenue_publicip.go
+++ b/v1/cloudavenue_publicip.go
@@ -13,55 +13,108 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/internal/endpoints"
 	clientcloudavenue "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/clients/cloudavenue"
 	commoncloudavenue "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/cloudavenue"
 )
 
 type PublicIP struct{}
 
+// IPs represents the list of public IPs (legacy format for backward compatibility).
 type IPs struct {
-	InternalIP    string `json:"internalIp"`
-	NetworkConfig []IP   `json:"networkConfig"`
+	NetworkConfig []IP `json:"networkConfig"`
 }
 
+// IP represents a public IP address.
 type IP struct {
 	UplinkIP        string `json:"uplinkIp"`
-	TranslatedIP    string `json:"translatedIp"`
 	EdgeGatewayName string `json:"edgeGatewayName"`
+	Announced       bool   `json:"announced"`
+	// ServiceID is the service identifier used for delete operations.
+	ServiceID string `json:"serviceId"`
 }
 
-// GetIP - Returns the public IP.
+// GetIP - Returns the public IP address.
 func (i *IP) GetIP() string {
 	return i.UplinkIP
 }
 
-// GetIPs - Returns the list of public IPs.
+// networkHierarchyResponse represents the response from /network endpoint.
+type networkHierarchyResponse []networkHierarchyItem
+
+type networkHierarchyItem struct {
+	Type        string                 `json:"type"`
+	Name        string                 `json:"name"`
+	DisplayName string                 `json:"displayName,omitempty"`
+	Properties  networkItemProperties  `json:"properties,omitempty"`
+	Children    []networkHierarchyItem `json:"children,omitempty"`
+	ServiceID   string                 `json:"serviceId,omitempty"`
+}
+
+type networkItemProperties struct {
+	// Edge Gateway properties
+	RateLimit int    `json:"rateLimit,omitempty"`
+	EdgeUUID  string `json:"edgeUUID,omitempty"`
+	// Internet service properties
+	IP        string `json:"ip,omitempty"`
+	Announced bool   `json:"announced,omitempty"`
+}
+
+// GetIPs - Returns the list of public IPs from the network hierarchy.
 func (v *PublicIP) GetIPs() (response *IPs, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	r, err := c.R().
-		SetResult(&IPs{}).
+		SetResult(&networkHierarchyResponse{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/infrapicustomerproxy/v2.0/ip")
+		Get(endpoints.NetworkServiceGet)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if r.IsError() {
-		return response, fmt.Errorf("error on get public IPs: %s", r.Error().(*commoncloudavenue.APIErrorResponse).FormatError())
+		return nil, fmt.Errorf("error on get public IPs: %s", r.Error().(*commoncloudavenue.APIErrorResponse).FormatError())
 	}
 
-	return r.Result().(*IPs), nil
+	hierarchy := r.Result().(*networkHierarchyResponse)
+	if hierarchy == nil {
+		return &IPs{NetworkConfig: []IP{}}, nil
+	}
+
+	// Extract public IPs from the hierarchy
+	ips := &IPs{NetworkConfig: []IP{}}
+	for _, vrf := range *hierarchy {
+		if vrf.Type != "tier-0-vrf" {
+			continue
+		}
+		for _, child := range vrf.Children {
+			if child.Type == "edge-gateway" {
+				edgeGatewayName := child.Name
+				for _, service := range child.Children {
+					if service.Type == "service" && service.Name == "internet" {
+						ips.NetworkConfig = append(ips.NetworkConfig, IP{
+							UplinkIP:        service.Properties.IP,
+							EdgeGatewayName: edgeGatewayName,
+							Announced:       service.Properties.Announced,
+							ServiceID:       service.ServiceID,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return ips, nil
 }
 
-// GetIPsByEdgeGateway - Returns the list of public IPs by edge gateway.
+// GetIPsByEdgeGateway - Returns the list of public IPs by edge gateway name.
 func (v *PublicIP) GetIPsByEdgeGateway(edgeGatewayName string) (response *IPs, err error) {
 	ipS, err := v.GetIPs()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	var ipsByEdgeGateway IPs
@@ -74,11 +127,11 @@ func (v *PublicIP) GetIPsByEdgeGateway(edgeGatewayName string) (response *IPs, e
 	return &ipsByEdgeGateway, nil
 }
 
-// GetIP - Returns the public IP by edge gateway.
+// GetIP - Returns the public IP by IP address.
 func (v *PublicIP) GetIP(publicIP string) (response *IP, err error) {
 	ipS, err := v.GetIPs()
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	for _, ip := range ipS.NetworkConfig {
@@ -108,54 +161,70 @@ func (v *PublicIP) GetIPByJob(job *commoncloudavenue.JobStatus) (response *IP, e
 	return nil, fmt.Errorf("public IP not found")
 }
 
-// New - Returns a new PublicIP.
-func (v *PublicIP) New(edgeGatewayName string) (job *commoncloudavenue.JobStatus, err error) {
+// internetServiceRequest represents the request body for creating an internet service.
+type internetServiceRequest struct {
+	NetworkType string `json:"networkType"`
+	EdgeGateway string `json:"edgeGateway"`
+}
+
+// New - Creates a new public IP on the specified edge gateway.
+// The edgeGatewayID must be the UUID of the edge gateway (not the name).
+func (v *PublicIP) New(edgeGatewayID string) (job *commoncloudavenue.JobStatus, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	if edgeGatewayName == "" {
-		return nil, fmt.Errorf("edgeGatewayName is empty")
+	if edgeGatewayID == "" {
+		return nil, fmt.Errorf("edgeGatewayID is empty")
+	}
+
+	req := internetServiceRequest{
+		NetworkType: "internet",
+		EdgeGateway: edgeGatewayID,
 	}
 
 	r, err := c.R().
-		SetHeader("X-VDC-Edge-Name", edgeGatewayName).
-		SetResult(&commoncloudavenue.JobCreatedAPIResponse{}).
+		SetBody(req).
+		SetResult(&commoncloudavenue.JobStatus{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Post("/infrapicustomerproxy/v1.0/ip")
+		Post(endpoints.NetworkServiceCreate)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if r.IsError() {
 		return nil, fmt.Errorf("error on create public IP: %s", r.Error().(*commoncloudavenue.APIErrorResponse).FormatError())
 	}
 
-	return r.Result().(*commoncloudavenue.JobCreatedAPIResponse).GetJobStatus()
+	return r.Result().(*commoncloudavenue.JobStatus), nil
 }
 
 // Delete - Deletes a public IP.
 func (i *IP) Delete() (job *commoncloudavenue.JobStatus, err error) {
+	if i.ServiceID == "" {
+		return nil, fmt.Errorf("serviceID is empty, cannot delete public IP %s", i.UplinkIP)
+	}
+
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	r, err := c.R().
 		SetPathParams(map[string]string{
-			"PublicIP": i.UplinkIP,
+			"service-id": i.ServiceID,
 		}).
-		SetResult(&commoncloudavenue.JobCreatedAPIResponse{}).
+		SetResult(&commoncloudavenue.JobStatus{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Delete("/infrapicustomerproxy/v1.0/ip/{PublicIP}/")
+		Delete(endpoints.NetworkServiceDelete)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if r.IsError() {
 		return nil, fmt.Errorf("error on delete public IP: %s", r.Error().(*commoncloudavenue.APIErrorResponse).FormatError())
 	}
 
-	return r.Result().(*commoncloudavenue.JobCreatedAPIResponse).GetJobStatus()
+	return r.Result().(*commoncloudavenue.JobStatus), nil
 }

--- a/v1/cloudavenue_publicip.go
+++ b/v1/cloudavenue_publicip.go
@@ -170,13 +170,13 @@ type internetServiceRequest struct {
 // New - Creates a new public IP on the specified edge gateway.
 // The edgeGatewayID must be the UUID of the edge gateway (not the name).
 func (v *PublicIP) New(edgeGatewayID string) (job *commoncloudavenue.JobStatus, err error) {
+	if edgeGatewayID == "" {
+		return nil, fmt.Errorf("edgeGatewayID is empty")
+	}
+
 	c, err := clientcloudavenue.New()
 	if err != nil {
 		return nil, err
-	}
-
-	if edgeGatewayID == "" {
-		return nil, fmt.Errorf("edgeGatewayID is empty")
 	}
 
 	req := internetServiceRequest{

--- a/v1/cloudavenue_publicip.go
+++ b/v1/cloudavenue_publicip.go
@@ -45,7 +45,7 @@ func (v *PublicIP) GetIPs() (response *IPs, err error) {
 	r, err := c.R().
 		SetResult(&IPs{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/ip")
+		Get("/infrapicustomerproxy/v2.0/ip")
 	if err != nil {
 		return
 	}
@@ -123,7 +123,7 @@ func (v *PublicIP) New(edgeGatewayName string) (job *commoncloudavenue.JobStatus
 		SetHeader("X-VDC-Edge-Name", edgeGatewayName).
 		SetResult(&commoncloudavenue.JobCreatedAPIResponse{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Post("/api/customers/v1.0/ip")
+		Post("/infrapicustomerproxy/v1.0/ip")
 	if err != nil {
 		return
 	}
@@ -148,7 +148,7 @@ func (i *IP) Delete() (job *commoncloudavenue.JobStatus, err error) {
 		}).
 		SetResult(&commoncloudavenue.JobCreatedAPIResponse{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Delete("/api/customers/v1.0/ip/{PublicIP}/")
+		Delete("/infrapicustomerproxy/v1.0/ip/{PublicIP}/")
 	if err != nil {
 		return
 	}

--- a/v1/cloudavenue_t0.go
+++ b/v1/cloudavenue_t0.go
@@ -141,7 +141,7 @@ func (t *Tier0) GetT0s() (listOfT0s *T0s, err error) {
 	r, err := c.R().
 		SetResult(&[]string{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/tier-0-vrfs")
+		Get("/infrapicustomerproxy/v2.0/tier-0-vrfs")
 	if err != nil {
 		return
 	}
@@ -175,7 +175,7 @@ func (t *Tier0) GetT0(t0 string) (response *T0, err error) {
 		SetResult(&T0{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("t0Name", t0).
-		Get("/api/customers/v2.0/tier-0-vrfs/{t0Name}")
+		Get("/infrapicustomerproxy/v2.0/tier-0-vrfs/{t0Name}")
 	if err != nil {
 		return
 	}

--- a/v1/cloudavenue_t0.go
+++ b/v1/cloudavenue_t0.go
@@ -135,7 +135,7 @@ func (c ClassService) IsVRFDedicatedLarge() bool {
 func (t *Tier0) GetT0s() (listOfT0s *T0s, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return listOfT0s, err
 	}
 
 	r, err := c.R().
@@ -143,7 +143,7 @@ func (t *Tier0) GetT0s() (listOfT0s *T0s, err error) {
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		Get("/infrapicustomerproxy/v2.0/tier-0-vrfs")
 	if err != nil {
-		return
+		return listOfT0s, err
 	}
 
 	if r.IsError() {
@@ -168,7 +168,7 @@ func (t *Tier0) GetT0s() (listOfT0s *T0s, err error) {
 func (t *Tier0) GetT0(t0 string) (response *T0, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	r, err := c.R().
@@ -177,7 +177,7 @@ func (t *Tier0) GetT0(t0 string) (response *T0, err error) {
 		SetPathParam("t0Name", t0).
 		Get("/infrapicustomerproxy/v2.0/tier-0-vrfs/{t0Name}")
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if r.IsError() {

--- a/v1/cloudavenue_vcda.go
+++ b/v1/cloudavenue_vcda.go
@@ -34,7 +34,7 @@ func (v *VCDA) List() (VDCAIps, error) {
 	r, err := c.R().
 		SetResult(&VDCAIps{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/vcda/ips")
+		Get("/infrapicustomerproxy/v2.0/vcda/ips")
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (v *VCDA) RegisterIP(ip string) error {
 	r, err := c.R().
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("ip", ip).
-		Post("/api/customers/v2.0/vcda/ips/{ip}/")
+		Post("/infrapicustomerproxy/v2.0/vcda/ips/{ip}/")
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (v *VDCAIps) DeleteIP(ip string) error {
 	r, err := c.R().
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("ip", ip).
-		Delete("/api/customers/v2.0/vcda/ips/{ip}/")
+		Delete("/infrapicustomerproxy/v2.0/vcda/ips/{ip}/")
 	if err != nil {
 		return err
 	}

--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -58,7 +58,7 @@ func (v *EdgeGateway) List() (response *EdgeGateways, err error) {
 	r, err := c.R().
 		SetResult(&EdgeGateways{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/edges")
+		Get("/infrapicustomerproxy/v2.0/edges")
 	if err != nil {
 		return
 	}
@@ -126,7 +126,7 @@ func (v *EdgeGateway) New(vdcName, tier0VrfName string) (job *commoncloudavenue.
 			"tier0VrfId": tier0VrfName,
 		}).
 		SetPathParam("VdcName", vdcName).
-		Post("/api/customers/v2.0/vdcs/{VdcName}/edges")
+		Post("/infrapicustomerproxy/v2.0/vdcs/{VdcName}/edges")
 	if err != nil {
 		return
 	}
@@ -152,7 +152,7 @@ func (v *EdgeGateway) NewFromVDCGroup(vdcGroupName, tier0VrfName string) (job *c
 			"tier0VrfId": tier0VrfName,
 		}).
 		SetPathParam("VdcGroupName", vdcGroupName).
-		Post("/api/customers/v2.0/vdc-groups/{VdcGroupName}/edges")
+		Post("/infrapicustomerproxy/v2.0/vdc-groups/{VdcGroupName}/edges")
 	if err != nil {
 		return
 	}
@@ -201,7 +201,7 @@ func (v *EdgeGateway) Get(edgeGatewayNameOrID string) (edgeClient *EdgeClient, e
 				SetPathParams(map[string]string{
 					"EdgeID": strings.TrimPrefix(nameOrID.String(), urn.Gateway.String()),
 				}).
-				Get("/api/customers/v2.0/edges/{EdgeID}")
+				Get("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func (e *EdgeGatewayType) Delete() (job *commoncloudavenue.JobStatus, err error)
 		SetPathParams(map[string]string{
 			"EdgeID": e.EdgeID,
 		}).
-		Delete("/api/customers/v2.0/edges/{EdgeID}")
+		Delete("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
 		return
 	}
@@ -297,7 +297,7 @@ func (e *EdgeGatewayType) UpdateBandwidth(rateLimit int) (job *commoncloudavenue
 		SetPathParams(map[string]string{
 			"EdgeID": e.EdgeID,
 		}).
-		Put("/api/customers/v2.0/edges/{EdgeID}")
+		Put("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
 		return
 	}
@@ -424,7 +424,7 @@ func (e *EdgeGatewayType) ListNetworksType() (response *NetworkTypes, err error)
 		SetPathParams(map[string]string{
 			"EdgeID": e.EdgeID,
 		}).
-		Get("/api/customers/v2.0/edges/{EdgeID}/networks")
+		Get("/infrapicustomerproxy/v2.0/edges/{EdgeID}/networks")
 	if err != nil {
 		return
 	}

--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -52,7 +52,7 @@ func (e *EdgeClient) GetVmwareEdgeGateway() (*govcd.NsxtEdgeGateway, error) {
 func (v *EdgeGateway) List() (response *EdgeGateways, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	r, err := c.R().
@@ -60,7 +60,7 @@ func (v *EdgeGateway) List() (response *EdgeGateways, err error) {
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		Get("/infrapicustomerproxy/v2.0/edges")
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if r.IsError() {
@@ -74,7 +74,7 @@ func (v *EdgeGateway) List() (response *EdgeGateways, err error) {
 func (v *EdgeGateway) GetAllowedBandwidthValues(t0VrfName string) (allowedValues []int, err error) {
 	t0, err := (&Tier0{}).GetT0(t0VrfName)
 	if err != nil {
-		return
+		return allowedValues, err
 	}
 
 	if v, ok := EdgeGatewayAllowedBandwidth[t0.GetClassService()]; ok {
@@ -88,12 +88,12 @@ func (v *EdgeGateway) GetAllowedBandwidthValues(t0VrfName string) (allowedValues
 func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response int, err error) {
 	t0, err := (&Tier0{}).GetT0(t0VrfName)
 	if err != nil {
-		return
+		return response, err
 	}
 
 	t0BandwidthCapacity, err := t0.GetBandwidthCapacity()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	for _, edgeGateway := range *e {
@@ -116,7 +116,7 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 func (v *EdgeGateway) New(vdcName, tier0VrfName string) (job *commoncloudavenue.JobStatus, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return job, err
 	}
 
 	r, err := c.R().
@@ -128,7 +128,7 @@ func (v *EdgeGateway) New(vdcName, tier0VrfName string) (job *commoncloudavenue.
 		SetPathParam("VdcName", vdcName).
 		Post("/infrapicustomerproxy/v2.0/vdcs/{VdcName}/edges")
 	if err != nil {
-		return
+		return job, err
 	}
 
 	if r.IsError() {
@@ -142,7 +142,7 @@ func (v *EdgeGateway) New(vdcName, tier0VrfName string) (job *commoncloudavenue.
 func (v *EdgeGateway) NewFromVDCGroup(vdcGroupName, tier0VrfName string) (job *commoncloudavenue.JobStatus, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return job, err
 	}
 
 	r, err := c.R().
@@ -154,7 +154,7 @@ func (v *EdgeGateway) NewFromVDCGroup(vdcGroupName, tier0VrfName string) (job *c
 		SetPathParam("VdcGroupName", vdcGroupName).
 		Post("/infrapicustomerproxy/v2.0/vdc-groups/{VdcGroupName}/edges")
 	if err != nil {
-		return
+		return job, err
 	}
 
 	if r.IsError() {
@@ -253,7 +253,7 @@ func (v *EdgeGateway) GetByID(edgeGatewayID string) (edgeClient *EdgeClient, err
 func (e *EdgeGatewayType) Delete() (job *commoncloudavenue.JobStatus, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return job, err
 	}
 
 	r, err := c.R().
@@ -264,7 +264,7 @@ func (e *EdgeGatewayType) Delete() (job *commoncloudavenue.JobStatus, err error)
 		}).
 		Delete("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
-		return
+		return job, err
 	}
 
 	if r.IsError() {
@@ -285,7 +285,7 @@ func (e *EdgeGatewayType) GetBandwidth() int {
 func (e *EdgeGatewayType) UpdateBandwidth(rateLimit int) (job *commoncloudavenue.JobStatus, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return job, err
 	}
 
 	r, err := c.R().
@@ -299,7 +299,7 @@ func (e *EdgeGatewayType) UpdateBandwidth(rateLimit int) (job *commoncloudavenue
 		}).
 		Put("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
-		return
+		return job, err
 	}
 
 	if r.IsError() {
@@ -415,7 +415,7 @@ func (n NetworkType) GetEndAddress() string {
 func (e *EdgeGatewayType) ListNetworksType() (response *NetworkTypes, err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return response, err
 	}
 
 	r, err := c.R().
@@ -426,7 +426,7 @@ func (e *EdgeGatewayType) ListNetworksType() (response *NetworkTypes, err error)
 		}).
 		Get("/infrapicustomerproxy/v2.0/edges/{EdgeID}/networks")
 	if err != nil {
-		return
+		return response, err
 	}
 
 	if r.IsError() {

--- a/v1/infrapi/vdc.go
+++ b/v1/infrapi/vdc.go
@@ -204,7 +204,7 @@ func (v *CAVVDC) Get(vdcName string) (*CAVVirtualDataCenter, error) {
 		SetResult(&CAVVirtualDataCenter{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("vdcName", vdcName).
-		Get("/api/customers/v2.0/vdcs/{vdcName}")
+		Get("/infrapicustomerproxy/v2.0/vdcs/{vdcName}")
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (v *CAVVDC) List() (*VDCs, error) {
 	r, err := c.R().
 		SetResult(&listOfVDCs{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/vdcs")
+		Get("/infrapicustomerproxy/v2.0/vdcs")
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (v *CAVVirtualDataCenter) Delete(ctx context.Context) (err error) {
 		SetResult(&commoncloudavenue.JobStatus{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("vdcName", v.VDC.Name).
-		Delete("/api/customers/v2.0/vdcs/{vdcName}")
+		Delete("/infrapicustomerproxy/v2.0/vdcs/{vdcName}")
 	if err != nil {
 		return
 	}
@@ -290,7 +290,7 @@ func (v *CAVVirtualDataCenter) Update(ctx context.Context) (err error) {
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParam("vdcName", v.VDC.Name).
 		SetResult(&commoncloudavenue.JobStatus{}).
-		Put("/api/customers/v2.0/vdcs/{vdcName}")
+		Put("/infrapicustomerproxy/v2.0/vdcs/{vdcName}")
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func (v *CAVVDC) New(ctx context.Context, value *CAVVirtualDataCenter) (vdc *CAV
 		SetBody(value).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetResult(&commoncloudavenue.JobStatus{}).
-		Post("/api/customers/v2.0/vdcs")
+		Post("/infrapicustomerproxy/v2.0/vdcs")
 	if err != nil {
 		return
 	}

--- a/v1/infrapi/vdc.go
+++ b/v1/infrapi/vdc.go
@@ -259,7 +259,7 @@ func (v *CAVVDC) List() (*VDCs, error) {
 func (v *CAVVirtualDataCenter) Delete(ctx context.Context) (err error) {
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return err
 	}
 
 	r, err := c.R().
@@ -268,7 +268,7 @@ func (v *CAVVirtualDataCenter) Delete(ctx context.Context) (err error) {
 		SetPathParam("vdcName", v.VDC.Name).
 		Delete("/infrapicustomerproxy/v2.0/vdcs/{vdcName}")
 	if err != nil {
-		return
+		return err
 	}
 
 	if r.IsError() {
@@ -310,7 +310,7 @@ func (v *CAVVDC) New(ctx context.Context, value *CAVVirtualDataCenter) (vdc *CAV
 
 	c, err := clientcloudavenue.New()
 	if err != nil {
-		return
+		return vdc, err
 	}
 
 	r, err := c.R().
@@ -319,7 +319,7 @@ func (v *CAVVDC) New(ctx context.Context, value *CAVVirtualDataCenter) (vdc *CAV
 		SetResult(&commoncloudavenue.JobStatus{}).
 		Post("/infrapicustomerproxy/v2.0/vdcs")
 	if err != nil {
-		return
+		return vdc, err
 	}
 
 	if r.IsError() {

--- a/v1/netbackup/netbackup_machines.go
+++ b/v1/netbackup/netbackup_machines.go
@@ -209,7 +209,7 @@ type machinesResponse struct {
 func (m *MachineClient) GetMachines() (resp *Machines, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -217,7 +217,7 @@ func (m *MachineClient) GetMachines() (resp *Machines, err error) {
 		SetError(&commonnetbackup.APIError{}).
 		Get("/v6/machines")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -235,7 +235,7 @@ type machineResponse struct {
 func (m *MachineClient) GetMachineByID(id int) (resp *Machine, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -244,7 +244,7 @@ func (m *MachineClient) GetMachineByID(id int) (resp *Machine, err error) {
 		SetPathParam("id", fmt.Sprintf("%d", id)).
 		Get("/v6/machines/{id}")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -258,7 +258,7 @@ func (m *MachineClient) GetMachineByID(id int) (resp *Machine, err error) {
 func (m *MachineClient) GetMachineByName(name string) (resp *Machine, err error) {
 	machines, err := m.GetMachines()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, machine := range *machines {
@@ -274,7 +274,7 @@ func (m *MachineClient) GetMachineByName(name string) (resp *Machine, err error)
 func (m *MachineClient) GetMachineByIdentifier(identifier string) (resp *Machine, err error) {
 	machines, err := m.GetMachines()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, machine := range *machines {
@@ -290,7 +290,7 @@ func (m *MachineClient) GetMachineByIdentifier(identifier string) (resp *Machine
 func (m *MachineClient) GetMachineByNameOrIdentifier(nameOrIdentifier string) (resp *Machine, err error) {
 	machines, err := m.GetMachines()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, machine := range *machines {

--- a/v1/netbackup/netbackup_vcloud_org.go
+++ b/v1/netbackup/netbackup_vcloud_org.go
@@ -72,7 +72,7 @@ type orgsResponse struct {
 func (v *VcloudClient) GetOrgs() (resp *Orgs, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -80,7 +80,7 @@ func (v *VcloudClient) GetOrgs() (resp *Orgs, err error) {
 		SetError(&commonnetbackup.APIError{}).
 		Get("/v6/vcloud/orgs")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -100,7 +100,7 @@ type orgResponse struct {
 func (v *VcloudClient) GetOrg(id int) (resp *Org, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -111,7 +111,7 @@ func (v *VcloudClient) GetOrg(id int) (resp *Org, err error) {
 		}).
 		Get("/v6/vcloud/orgs/{orgID}")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -125,7 +125,7 @@ func (v *VcloudClient) GetOrg(id int) (resp *Org, err error) {
 func (v *VcloudClient) GetOrgByName(name string) (resp *Org, err error) {
 	orgs, err := v.GetOrgs()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, org := range *orgs {

--- a/v1/netbackup/netbackup_vcloud_vapp.go
+++ b/v1/netbackup/netbackup_vcloud_vapp.go
@@ -71,7 +71,7 @@ type VAppsResponse struct {
 func (v *VcloudClient) GetVApps() (resp *VApps, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -79,7 +79,7 @@ func (v *VcloudClient) GetVApps() (resp *VApps, err error) {
 		SetError(&commonnetbackup.APIError{}).
 		Get("/v6/vcloud/vapps")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -100,7 +100,7 @@ type VAppResponse struct {
 func (v *VcloudClient) GetVAppByID(id int) (resp *VApp, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -111,7 +111,7 @@ func (v *VcloudClient) GetVAppByID(id int) (resp *VApp, err error) {
 		}).
 		Get("/v6/vcloud/vapps/{vAppID}")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -126,7 +126,7 @@ func (v *VcloudClient) GetVAppByID(id int) (resp *VApp, err error) {
 func (v *VcloudClient) GetVAppByName(name string) (resp *VApp, err error) {
 	vapps, err := v.GetVApps()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vapp := range *vapps {
@@ -143,7 +143,7 @@ func (v *VcloudClient) GetVAppByName(name string) (resp *VApp, err error) {
 func (v *VcloudClient) GetVAppByIdentifier(identifier string) (resp *VApp, err error) {
 	vapps, err := v.GetVApps()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vapp := range *vapps {
@@ -160,7 +160,7 @@ func (v *VcloudClient) GetVAppByIdentifier(identifier string) (resp *VApp, err e
 func (v *VcloudClient) GetVAppByNameOrIdentifier(nameOrIdentifier string) (resp *VApp, err error) {
 	vapps, err := v.GetVApps()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vapp := range *vapps {
@@ -215,7 +215,7 @@ type GetVAppMachinesResponse struct {
 func (v *VcloudClient) GetVAppMachines(vAppID int) (resp *GetVAppMachinesResponse, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -226,7 +226,7 @@ func (v *VcloudClient) GetVAppMachines(vAppID int) (resp *GetVAppMachinesRespons
 		}).
 		Get("/v6/vcloud/vapps/{vAppID}/machines")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {

--- a/v1/netbackup/netbackup_vcloud_vdc.go
+++ b/v1/netbackup/netbackup_vcloud_vdc.go
@@ -75,7 +75,7 @@ type vdcsResponse struct {
 func (v *VcloudClient) GetVdcs() (resp *VDCs, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -83,7 +83,7 @@ func (v *VcloudClient) GetVdcs() (resp *VDCs, err error) {
 		SetError(&commonnetbackup.APIError{}).
 		Get("/v6/vcloud/vdcs")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -98,7 +98,7 @@ func (v *VcloudClient) GetVdcs() (resp *VDCs, err error) {
 func (v *VcloudClient) GetVdcsByOrgID(orgID int) (resp *VDCs, err error) {
 	vdcs, err := v.GetVdcs()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vdc := range *vdcs {
@@ -119,7 +119,7 @@ type vdcResponse struct {
 func (v *VcloudClient) GetVDCByID(id int) (resp *VDC, err error) {
 	c, err := clientnetbackup.New()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	r, err := c.R().
@@ -130,7 +130,7 @@ func (v *VcloudClient) GetVDCByID(id int) (resp *VDC, err error) {
 		}).
 		Get("/v6/vcloud/vdcs/{vdcID}")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -145,7 +145,7 @@ func (v *VcloudClient) GetVDCByID(id int) (resp *VDC, err error) {
 func (v *VcloudClient) GetVDCByIdentifier(identifier string) (resp *VDC, err error) {
 	vdcs, err := v.GetVdcs()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vdc := range *vdcs {
@@ -162,7 +162,7 @@ func (v *VcloudClient) GetVDCByIdentifier(identifier string) (resp *VDC, err err
 func (v *VcloudClient) GetVDCByName(name string) (resp *VDC, err error) {
 	vdcs, err := v.GetVdcs()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vdc := range *vdcs {
@@ -179,7 +179,7 @@ func (v *VcloudClient) GetVDCByName(name string) (resp *VDC, err error) {
 func (v *VcloudClient) GetVDCByNameOrIdentifier(nameOrIdentifier string) (resp *VDC, err error) {
 	vdcs, err := v.GetVdcs()
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	for _, vdc := range *vdcs {

--- a/v1/org/properties.go
+++ b/v1/org/properties.go
@@ -35,7 +35,7 @@ func (c *client) GetProperties(ctx context.Context) (values *PropertiesModel, er
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		Get("/infrapicustomerproxy/v2.0/configurations")
 	if err != nil {
-		return
+		return values, err
 	}
 
 	if r.IsError() {

--- a/v1/org/properties.go
+++ b/v1/org/properties.go
@@ -33,7 +33,7 @@ func (c *client) GetProperties(ctx context.Context) (values *PropertiesModel, er
 		SetContext(ctx).
 		SetResult(&propertiesResponse{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Get("/api/customers/v2.0/configurations")
+		Get("/infrapicustomerproxy/v2.0/configurations")
 	if err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (c *client) UpdateProperties(ctx context.Context, properties *PropertiesReq
 		SetBody(properties).
 		SetResult(&commoncloudavenue.JobCreatedAPIResponse{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
-		Put("/api/customers/v2.0/configurations")
+		Put("/infrapicustomerproxy/v2.0/configurations")
 	if err != nil {
 		return nil, err
 	}

--- a/v1/org/properties_test.go
+++ b/v1/org/properties_test.go
@@ -51,7 +51,7 @@ func TestClient_GetProperties(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					httpmock.RegisterResponder("GET", "/api/customers/v2.0/configurations", responder)
+					httpmock.RegisterResponder("GET", "/infrapicustomerproxy/v2.0/configurations", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -92,7 +92,7 @@ func TestClient_GetProperties(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					httpmock.RegisterResponder("GET", "/api/customers/v2.0/configurations", responder)
+					httpmock.RegisterResponder("GET", "/infrapicustomerproxy/v2.0/configurations", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -107,7 +107,7 @@ func TestClient_GetProperties(t *testing.T) {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
 					responder := httpmock.NewStringResponder(200, ``)
 
-					httpmock.RegisterResponder("GET", "/api/customers/v2.0/bad/path", responder)
+					httpmock.RegisterResponder("GET", "/infrapicustomerproxy/v2.0/bad/path", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -163,7 +163,7 @@ func TestClient_UpdateProperties(t *testing.T) {
 						t.Fatal(err)
 					}
 					httpmock.BodyContainsBytes(json.RawMessage(`{"fullName":"John Doe","description":"John Doe description","customerMail":"","internetBillingMode":"PAYG"}`))
-					httpmock.RegisterResponder("PUT", "/api/customers/v2.0/configurations", responder)
+					httpmock.RegisterResponder("PUT", "/infrapicustomerproxy/v2.0/configurations", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -219,7 +219,7 @@ func TestClient_UpdateProperties(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("PUT", "/api/customers/v2.0/configurations", responder)
+					httpmock.RegisterResponder("PUT", "/infrapicustomerproxy/v2.0/configurations", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -242,7 +242,7 @@ func TestClient_UpdateProperties(t *testing.T) {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
 					responder := httpmock.NewStringResponder(200, ``)
 
-					httpmock.RegisterResponder("PUT", "/api/customers/v2.0/bad/path", responder)
+					httpmock.RegisterResponder("PUT", "/infrapicustomerproxy/v2.0/bad/path", responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},

--- a/v1/s3_bucket.go
+++ b/v1/s3_bucket.go
@@ -49,7 +49,7 @@ func (s S3Client) SyncBucket(bucketName string) (err error) {
 		SetQueryParam("sync", "").
 		Get("/api/v1/s3/{bucketName}")
 	if err != nil {
-		return
+		return err
 	}
 
 	if r.IsError() {

--- a/v1/s3_credential.go
+++ b/v1/s3_credential.go
@@ -116,7 +116,7 @@ func (s *S3User) GetCredentials() (resp *S3Credentials, err error) {
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users/{userName}/credentials")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -137,7 +137,7 @@ func (s *S3User) GetCredential(accessKey string) (resp *S3Credential, err error)
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users/{userName}/credentials/{accessKey}")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -157,7 +157,7 @@ func (s *S3User) NewCredential() (resp *S3Credential, err error) {
 		}).
 		Post("/api/v1/core/tenants/{orgID}/users/{userName}/credentials")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {
@@ -177,7 +177,7 @@ func (c *S3Credential) Delete() (err error) {
 		}).
 		Delete("/api/v1/core/tenants/{orgID}/users/{userName}/credentials/{accessKey}")
 	if err != nil {
-		return
+		return err
 	}
 
 	if r.IsError() {

--- a/v1/s3_user.go
+++ b/v1/s3_user.go
@@ -197,7 +197,7 @@ func (s S3Client) GetUsers() (resp *S3Users, err error) {
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users")
 	if err != nil {
-		return
+		return resp, err
 	}
 
 	if r.IsError() {


### PR DESCRIPTION
This pull request migrates the CloudAvenue SDK from legacy per-console endpoints and authentication to a unified Cerberus API endpoint and OAuth2 client credentials authentication flow. The update modernizes token handling, endpoint management, and client initialization, while maintaining backward compatibility for legacy fields and URLs.

**Cerberus API migration and endpoint unification:**

- All API endpoints in `internal/endpoints` are updated to use the unified Cerberus API path (`/infrapicustomerproxy/...`) instead of legacy `/api/customers/...` paths. (`[[1]](diffhunk://#diff-50904287faf225d88921acd53d924f1033192fe0394206029f61fddcd5dede65L14-R23)`, `[[2]](diffhunk://#diff-72edbf49a8d8dea013261a75014572ee640086459a593ee7d0cdde31800352c4L13-R13)`)
- A new constant `CerberusAPIEndpoint` is introduced in `consoles.go`, and all consoles now reference this endpoint for API calls, with legacy URLs retained for reference. (`[[1]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491R18-R21)`, `[[2]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L62-R66)`, `[[3]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L79-R83)`, `[[4]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L97-R101)`, `[[5]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L110-R114)`, `[[6]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L124-R128)`, `[[7]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L137-R141)`, `[[8]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L151-R155)`)

**Authentication and token handling overhaul:**

- The authentication flow is rewritten to use OAuth2 client credentials against the Cerberus API (`/auth/v1/user/token`), replacing the previous basic authentication and custom token logic. (`[[1]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`, `[[2]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R58-R174)`)
- The `token` struct is refactored to store OAuth2 fields (`accessToken`, `tokenType`, `expiresAt`, `clientID`, `clientSecret`), and methods are updated for the new flow. (`[[1]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`, `[[2]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R58-R174)`)
- Token refresh logic is updated to properly parse Cerberus responses and handle errors with new response types. (`[pkg/clients/cloudavenue/token.goR58-R174](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R58-R174)`)

**Client initialization and configuration updates:**

- The `Opts` struct and related client initialization logic are updated to reflect OAuth2 usage, with fields renamed for clarity (`Username`/`Password` as `client_id`/`client_secret`, `Org` as OAuth2 scope). (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501R29-L43)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L91-L120)`)
- The VMware client initialization now uses a default API version constant and authenticates with OAuth2 credentials. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501R29-L43)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L174-R169)`)
- The REST client setup now uses the Cerberus API endpoint, unified headers, and the new token scheme. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L191-R201)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L244-R243)`)

**Backward compatibility and legacy support:**

- Legacy fields, URLs, and error types are retained for compatibility, with clear comments and separation from new Cerberus logic. (`[[1]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`, `[[2]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L26-R30)`, `[[3]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L236-R252)`)
- Functions for legacy URL lookups and organization ID handling are preserved or commented for future removal. (`[[1]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491R178-R180)`, `[[2]](diffhunk://#diff-9eceef3cb9ca6d885bb0cc8d8f1e6ada8f1847e8a71d7eff4af2975fa33ca7f7L12-R16)`, `[[3]](diffhunk://#diff-9eceef3cb9ca6d885bb0cc8d8f1e6ada8f1847e8a71d7eff4af2975fa33ca7f7L31-R27)`)

**Code cleanup and documentation:**

- Unused imports and outdated code are removed, and comments are updated to clarify new authentication and endpoint usage. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L20)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501R29-L43)`, `[[3]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`)

---

**Most important changes:**

**1. Cerberus API migration and endpoint unification**
- All API endpoints in `internal/endpoints` now use the unified Cerberus API path (`/infrapicustomerproxy/...`) instead of legacy paths, centralizing API access. (`[[1]](diffhunk://#diff-50904287faf225d88921acd53d924f1033192fe0394206029f61fddcd5dede65L14-R23)`, `[[2]](diffhunk://#diff-72edbf49a8d8dea013261a75014572ee640086459a593ee7d0cdde31800352c4L13-R13)`)
- Added `CerberusAPIEndpoint` constant and updated consoles to reference this endpoint, with legacy URLs retained for backward compatibility. (`[[1]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491R18-R21)`, `[[2]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L62-R66)`, `[[3]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L79-R83)`, `[[4]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L97-R101)`, `[[5]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L110-R114)`, `[[6]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L124-R128)`, `[[7]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L137-R141)`, `[[8]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L151-R155)`)

**2. Authentication and token handling overhaul**
- Replaced legacy authentication with OAuth2 client credentials flow against Cerberus API, updating the `token` struct and refresh logic. (`[[1]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`, `[[2]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R58-R174)`)
- Introduced new response types for Cerberus authentication and error handling, and updated all token-related methods accordingly. (`[pkg/clients/cloudavenue/token.goR58-R174](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R58-R174)`)

**3. Client initialization and configuration updates**
- Refactored `Opts` struct and client initialization to use OAuth2 credentials and the unified endpoint, with improved field naming and validation. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501R29-L43)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L91-L120)`, `[[3]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L174-R169)`)
- Updated REST client setup to use Cerberus API endpoint, unified headers, and new token scheme. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L191-R201)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L244-R243)`)

**4. Backward compatibility and legacy support**
- Maintained legacy fields, URLs, and error types for compatibility, with clear comments and separation from new Cerberus logic. (`[[1]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`, `[[2]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L26-R30)`, `[[3]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491L236-R252)`)
- Preserved or commented out legacy functions for organization ID validation and URL lookups. (`[[1]](diffhunk://#diff-9a8b71f78090747ab5be065b2626e960e78d051087ba4586a5b5e8d0ab433491R178-R180)`, `[[2]](diffhunk://#diff-9eceef3cb9ca6d885bb0cc8d8f1e6ada8f1847e8a71d7eff4af2975fa33ca7f7L12-R16)`, `[[3]](diffhunk://#diff-9eceef3cb9ca6d885bb0cc8d8f1e6ada8f1847e8a71d7eff4af2975fa33ca7f7L31-R27)`)

**5. Code cleanup and documentation**
- Removed unused imports and outdated code, and updated comments to clarify the new authentication and endpoint usage. (`[[1]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501L20)`, `[[2]](diffhunk://#diff-fbce5c7b69750f4d697bca07d734768968f221844f69dc25295a8931fd84f501R29-L43)`, `[[3]](diffhunk://#diff-796a6452cc048e1b110caff699e805f9ffd7fbec244fe5a44fb7085cac471fc0R20-L32)`)