### PR TITLE
fix: panic on init S3 client

### DIFF
--- a/.changelog/299.txt
+++ b/.changelog/299.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix panic in the authentication s3 method. 
+```

--- a/cloudavenue.go
+++ b/cloudavenue.go
@@ -73,7 +73,7 @@ func New(opts *ClientOpts) (*Client, error) {
 			Username:         cavClient.GetUsername(),
 			OrganizationName: cavClient.GetOrganization(),
 			Debug:            cavClient.GetDebug(),
-			CAVToken:         clientcloudavenue.GetBearerToken(),
+			CAVToken:         clientcloudavenue.GetClient().Vmware.Client.VCDToken,
 		}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This pull request makes a targeted update to the authentication token retrieval in the `cloudavenue.go` file. Instead of using the `GetBearerToken()` method, the code now directly accesses the `VCDToken` property from the `Vmware.Client` object. This likely improves token accuracy or aligns with updated authentication flows. 

* Changed the initialization of the `Client` struct to fetch the token directly from `clientcloudavenue.GetClient().Vmware.Client.VCDToken` instead of using `GetBearerToken()`.