### PR TITLE
feat(cloudavenue): support CoreAPI backend override

### DIFF
--- a/.changelog/305.txt
+++ b/.changelog/305.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`pkg/clients/cloudavenue` - Add `CoreAPI` to override the backend API endpoint used for authentication and backend requests, with HTTPS validation and fallback to the default public endpoint.
+```

--- a/pkg/clients/cloudavenue/cloudavenue.go
+++ b/pkg/clients/cloudavenue/cloudavenue.go
@@ -44,6 +44,9 @@ type Opts struct {
 	VDC      string `env:"VDC,overwrite"`
 	Debug    bool   `env:"DEBUG,overwrite"`
 	Dev      bool   `env:"DEV,overwrite"` // Only for development
+	// CoreAPI overrides the default backend API endpoint.
+	// If empty, the default public endpoint is used (consoles.CerberusAPIEndpoint).
+	CoreAPI string `env:"CORE_API,overwrite"`
 }
 
 func (o *Opts) Validate() error {
@@ -90,6 +93,16 @@ func (o *Opts) Validate() error {
 		}
 	}
 
+	// If CoreAPI is not set, use the default backend API endpoint.
+	if o.CoreAPI == "" {
+		o.CoreAPI = consoles.CerberusAPIEndpoint
+	}
+
+	// Validate the backend URL format.
+	if u, err := url.ParseRequestURI(o.CoreAPI); err != nil || !u.IsAbs() || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("the core API %q has an %w", o.CoreAPI, errors.ErrInvalidFormat)
+	}
+
 	return nil
 }
 
@@ -109,6 +122,7 @@ func Init(opts *Opts) (err error) {
 	c.token.vdc = opts.VDC
 	c.token.endpoint = opts.URL
 	c.token.debug = opts.Debug
+	c.token.coreAPI = opts.CoreAPI
 
 	return err
 }
@@ -179,16 +193,9 @@ func New() (*Client, error) {
 		return cache.getAdminOrg()
 	})
 
-	// Setup Cerberus API client (InfrAPI proxy)
+	// Setup backend API client (auth + InfrAPI proxy)
 	wg.Go(func() error {
-		cache.Client = resty.New().
-			SetDebug(c.token.debug).
-			// SetHeader("Content-Type", "application/json").
-			SetHeader("Accept", "application/json").
-			SetBaseURL(consoles.CerberusAPIEndpoint).
-			SetAuthScheme("Bearer").
-			SetAuthToken(c.token.GetToken()).
-			SetHeader("User-Agent", "Cloudavenue-SDK-v1")
+		cache.Client = c.token.newBackendClient()
 
 		return nil
 	})

--- a/pkg/clients/cloudavenue/cloudavenue_test.go
+++ b/pkg/clients/cloudavenue/cloudavenue_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,13 +22,31 @@ import (
 	cloudavenueerrors "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/errors"
 )
 
+func clearCloudavenueEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"CLOUDAVENUE_CORE_API",
+		"CLOUDAVENUE_URL",
+		"CLOUDAVENUE_USERNAME",
+		"CLOUDAVENUE_PASSWORD",
+		"CLOUDAVENUE_ORG",
+		"CLOUDAVENUE_VDC",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("CLOUDAVENUE_DEBUG", "false")
+	t.Setenv("CLOUDAVENUE_DEV", "false")
+}
+
 func TestOptsValidateDefaultsCoreAPI(t *testing.T) {
+	clearCloudavenueEnv(t)
+	t.Setenv("CLOUDAVENUE_DEV", "true")
+
 	opts := &Opts{
 		URL:      "https://vcd.example.com",
 		Username: "username",
 		Password: "password",
 		Org:      "org",
-		Dev:      true,
 	}
 
 	err := opts.Validate()
@@ -49,12 +68,14 @@ func TestOptsValidateRejectsInvalidCoreAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			clearCloudavenueEnv(t)
+			t.Setenv("CLOUDAVENUE_DEV", "true")
+
 			opts := &Opts{
 				URL:      "https://vcd.example.com",
 				Username: "username",
 				Password: "password",
 				Org:      "org",
-				Dev:      true,
 				CoreAPI:  tt.coreAPI,
 			}
 
@@ -67,6 +88,8 @@ func TestOptsValidateRejectsInvalidCoreAPI(t *testing.T) {
 }
 
 func TestInitKeepsVMwareURLSeparatedFromCoreAPI(t *testing.T) {
+	clearCloudavenueEnv(t)
+	t.Setenv("CLOUDAVENUE_DEV", "true")
 	resetClientState(t)
 
 	opts := &Opts{
@@ -74,7 +97,6 @@ func TestInitKeepsVMwareURLSeparatedFromCoreAPI(t *testing.T) {
 		Username: "username",
 		Password: "password",
 		Org:      "org",
-		Dev:      true,
 		CoreAPI:  "https://core-api.example.com",
 	}
 
@@ -87,21 +109,27 @@ func TestInitKeepsVMwareURLSeparatedFromCoreAPI(t *testing.T) {
 }
 
 func TestTokenUsesCoreAPIForAuthAndBackendClient(t *testing.T) {
+	var mu sync.Mutex
 	var paths []string
 	var authHeaders []string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		paths = append(paths, r.URL.Path)
 		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		mu.Unlock()
 
 		switch r.URL.Path {
 		case "/auth/v1/user/token":
 			w.Header().Set("Content-Type", "application/json")
-			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			if err := json.NewEncoder(w).Encode(map[string]any{
 				"access_token": "access-token",
 				"token_type":   "Bearer",
 				"expires_in":   3600,
-			}))
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				assert.NoError(t, err)
+			}
 		case "/infrapicustomerproxy/v2.0/configurations":
 			w.WriteHeader(http.StatusOK)
 		default:
@@ -127,9 +155,16 @@ func TestTokenUsesCoreAPIForAuthAndBackendClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode())
 
-	assert.Equal(t, []string{"/auth/v1/user/token", "/infrapicustomerproxy/v2.0/configurations"}, paths)
-	assert.Equal(t, "", authHeaders[0])
-	assert.Equal(t, "Bearer access-token", authHeaders[1])
+	// All HTTP calls above complete synchronously; no concurrent writers remain at this point.
+	mu.Lock()
+	defer mu.Unlock()
+	if assert.Len(t, paths, 2) {
+		assert.Equal(t, []string{"/auth/v1/user/token", "/infrapicustomerproxy/v2.0/configurations"}, paths)
+	}
+	if assert.Len(t, authHeaders, 2) {
+		assert.Equal(t, "", authHeaders[0]) // auth endpoint uses no Authorization header — credentials are in the request body
+		assert.Equal(t, "Bearer access-token", authHeaders[1])
+	}
 }
 
 func TestTokenFallsBackToDefaultCoreAPIForAuthAndBackendClient(t *testing.T) {

--- a/pkg/clients/cloudavenue/cloudavenue_test.go
+++ b/pkg/clients/cloudavenue/cloudavenue_test.go
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package clientcloudavenue
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/clients/consoles"
+	cloudavenueerrors "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/errors"
+)
+
+func TestOptsValidateDefaultsCoreAPI(t *testing.T) {
+	opts := &Opts{
+		URL:      "https://vcd.example.com",
+		Username: "username",
+		Password: "password",
+		Org:      "org",
+		Dev:      true,
+	}
+
+	err := opts.Validate()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://vcd.example.com", opts.URL)
+	assert.Equal(t, consoles.CerberusAPIEndpoint, opts.CoreAPI)
+}
+
+func TestOptsValidateRejectsInvalidCoreAPI(t *testing.T) {
+	tests := []struct {
+		name    string
+		coreAPI string
+	}{
+		{name: "malformed URL", coreAPI: "://invalid"},
+		{name: "relative URL", coreAPI: "/backend"},
+		{name: "http URL", coreAPI: "http://core-api.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &Opts{
+				URL:      "https://vcd.example.com",
+				Username: "username",
+				Password: "password",
+				Org:      "org",
+				Dev:      true,
+				CoreAPI:  tt.coreAPI,
+			}
+
+			err := opts.Validate()
+
+			assert.ErrorIs(t, err, cloudavenueerrors.ErrInvalidFormat)
+			assert.EqualError(t, err, "the core API \""+tt.coreAPI+"\" has an invalid format")
+		})
+	}
+}
+
+func TestInitKeepsVMwareURLSeparatedFromCoreAPI(t *testing.T) {
+	resetClientState(t)
+
+	opts := &Opts{
+		URL:      "https://vcd.example.com",
+		Username: "username",
+		Password: "password",
+		Org:      "org",
+		Dev:      true,
+		CoreAPI:  "https://core-api.example.com",
+	}
+
+	err := Init(opts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "https://vcd.example.com", c.token.GetEndpoint())
+	assert.Equal(t, "https://core-api.example.com", c.token.effectiveCoreAPI())
+	assert.NotEqual(t, c.token.GetEndpoint(), c.token.effectiveCoreAPI())
+}
+
+func TestTokenUsesCoreAPIForAuthAndBackendClient(t *testing.T) {
+	var paths []string
+	var authHeaders []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+
+		switch r.URL.Path {
+		case "/auth/v1/user/token":
+			w.Header().Set("Content-Type", "application/json")
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}))
+		case "/infrapicustomerproxy/v2.0/configurations":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	token := token{
+		clientID:     "username",
+		clientSecret: "password",
+		org:          "org",
+		coreAPI:      server.URL,
+	}
+
+	err := token.RefreshToken()
+	assert.NoError(t, err)
+
+	backendClient := token.newBackendClient()
+	assert.Equal(t, server.URL, backendClient.BaseURL)
+
+	resp, err := backendClient.R().Get("/infrapicustomerproxy/v2.0/configurations")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+
+	assert.Equal(t, []string{"/auth/v1/user/token", "/infrapicustomerproxy/v2.0/configurations"}, paths)
+	assert.Equal(t, "", authHeaders[0])
+	assert.Equal(t, "Bearer access-token", authHeaders[1])
+}
+
+func TestTokenFallsBackToDefaultCoreAPIForAuthAndBackendClient(t *testing.T) {
+	token := token{
+		clientID:     "username",
+		clientSecret: "password",
+		org:          "org",
+	}
+
+	authClient := token.newAuthClient()
+	backendClient := token.newBackendClient()
+
+	assert.Equal(t, consoles.CerberusAPIEndpoint, authClient.BaseURL)
+	assert.Equal(t, consoles.CerberusAPIEndpoint, backendClient.BaseURL)
+	assert.Equal(t, authClient.BaseURL, backendClient.BaseURL)
+}
+
+func resetClientState(t *testing.T) {
+	t.Helper()
+
+	previousClient := c
+	previousCache := cache
+
+	c = &internalClient{}
+	cache = nil
+
+	t.Cleanup(func() {
+		c = previousClient
+		cache = previousCache
+	})
+}

--- a/pkg/clients/cloudavenue/token.go
+++ b/pkg/clients/cloudavenue/token.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/clients/consoles"
 )
 
 // token holds the OAuth2 authentication state for Cerberus API.
@@ -35,6 +37,7 @@ type token struct {
 
 	// Connection settings
 	endpoint string
+	coreAPI  string
 	debug    bool
 }
 
@@ -46,6 +49,28 @@ func (t *token) GetOrganization() string {
 // GetEndpoint - Returns the API endpoint.
 func (t *token) GetEndpoint() string {
 	return t.endpoint
+}
+
+func (t *token) effectiveCoreAPI() string {
+	if t.coreAPI == "" {
+		return consoles.CerberusAPIEndpoint
+	}
+
+	return t.coreAPI
+}
+
+func (t *token) newBackendClient() *resty.Client {
+	return resty.New().
+		SetDebug(t.debug).
+		SetHeader("Accept", "application/json").
+		SetBaseURL(t.effectiveCoreAPI()).
+		SetAuthScheme("Bearer").
+		SetAuthToken(t.GetToken()).
+		SetHeader("User-Agent", "Cloudavenue-SDK-v1")
+}
+
+func (t *token) newAuthClient() *resty.Client {
+	return resty.New().SetBaseURL(t.effectiveCoreAPI())
 }
 
 // GetEndpointURL - Returns the API endpoint URL.
@@ -97,7 +122,7 @@ func (t *token) RefreshToken() error {
 		return nil
 	}
 
-	c := resty.New().SetBaseURL("https://api1.cloudavenue.orange-business.com")
+	c := t.newAuthClient()
 
 	r, err := c.R().
 		SetDebug(t.debug).


### PR DESCRIPTION
## Summary
- keep `URL` dedicated to the VMware/VCD endpoint while introducing `CoreAPI` for backend auth and infra API calls
- validate `CoreAPI` as an absolute HTTPS URL and fall back to the default public endpoint when it is not set
- add tests and changelog entry for issue #305

## Testing
- `go test ./pkg/clients/cloudavenue`

## Notes
- `pkg/clients/consoles/consoles.go` intentionally left unchanged in this PR
- Closes #305