### PR TITLE
fix(lint): resolve all goconst violations across 26 files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.26.1
 	go.uber.org/mock v0.5.2
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
-	golang.org/x/mod v0.25.0
 	golang.org/x/sync v0.15.0
 )
 
@@ -77,6 +76,7 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.16.2 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect

--- a/pkg/clients/consoles/consoles_test.go
+++ b/pkg/clients/consoles/consoles_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 )
 
+const testConsole9Name = "should return the correct site name for Console9"
+
 func TestConsoles(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -57,19 +59,19 @@ func TestConsoles(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "should return the correct site name for Console9",
+			name:    testConsole9Name,
 			console: Console9,
 			orgName: "cav00vv09ocb0001234",
 			wantErr: false,
 		},
 		{
-			name:    "should return the correct site name for Console9",
+			name:    testConsole9Name,
 			console: Console9,
 			orgName: "cav01vv09ocb0001234",
 			wantErr: false,
 		},
 		{
-			name:    "should return the correct site name for Console9",
+			name:    testConsole9Name,
 			console: Console9,
 			orgName: "cav02vv09ocb0001234",
 			wantErr: false,

--- a/pkg/clients/netbackup/netbackup_test.go
+++ b/pkg/clients/netbackup/netbackup_test.go
@@ -16,6 +16,11 @@ import (
 	cavErrors "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/errors"
 )
 
+const (
+	testOrgName        = "cav01ev01ocb0001234"
+	testValidateErrFmt = "Opts.Validate() error = %v, wantErr %v"
+)
+
 func TestOpts_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -40,7 +45,7 @@ func TestOpts_Validate(t *testing.T) {
 		{
 			name: "should not return an error if the endpoint or the url are not empty and the organization is provided",
 			opts: &Opts{
-				org:      "cav01ev01ocb0001234",
+				org:      testOrgName,
 				Endpoint: "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api",
 			},
 			wantErr: nil,
@@ -55,7 +60,7 @@ func TestOpts_Validate(t *testing.T) {
 		{
 			name: "Validate console1",
 			opts: &Opts{
-				org: "cav01ev01ocb0001234",
+				org: testOrgName,
 			},
 			wantErr: nil,
 		},
@@ -66,15 +71,15 @@ func TestOpts_Validate(t *testing.T) {
 			err := tt.opts.Validate()
 
 			if tt.wantErr == nil && err != nil {
-				t.Errorf("Opts.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(testValidateErrFmt, err, tt.wantErr)
 			}
 
 			if tt.wantErr != nil && err == nil {
-				t.Errorf("Opts.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(testValidateErrFmt, err, tt.wantErr)
 			}
 
 			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("Opts.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf(testValidateErrFmt, err, tt.wantErr)
 			}
 
 			if tt.wantErr == nil && err == nil {
@@ -107,7 +112,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "should not set username, password, endpoint, and debug if not provided",
-			org:  "cav01ev01ocb0001234",
+			org:  testOrgName,
 			opts: &Opts{
 				Endpoint: "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api",
 			},
@@ -117,7 +122,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "should set username, password, and debug if provided",
-			org:  "cav01ev01ocb0001234",
+			org:  testOrgName,
 			opts: &Opts{
 				Username: "testuser",
 				Password: "testpass",

--- a/pkg/clients/netbackup/netbackup_test.go
+++ b/pkg/clients/netbackup/netbackup_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	testOrgName        = "cav01ev01ocb0001234"
-	testValidateErrFmt = "Opts.Validate() error = %v, wantErr %v"
+	testOrgName           = "cav01ev01ocb0001234"
+	testValidateErrFmt    = "Opts.Validate() error = %v, wantErr %v"
+	testNetbackupEndpoint = "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api"
 )
 
 func TestOpts_Validate(t *testing.T) {
@@ -46,14 +47,14 @@ func TestOpts_Validate(t *testing.T) {
 			name: "should not return an error if the endpoint or the url are not empty and the organization is provided",
 			opts: &Opts{
 				org:      testOrgName,
-				Endpoint: "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api",
+				Endpoint: testNetbackupEndpoint,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "should not return an error if the endpoint or the url are not empty and the organization is empty",
 			opts: &Opts{
-				URL: "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api",
+				URL: testNetbackupEndpoint,
 			},
 			wantErr: nil,
 		},
@@ -114,7 +115,7 @@ func TestInit(t *testing.T) {
 			name: "should not set username, password, endpoint, and debug if not provided",
 			org:  testOrgName,
 			opts: &Opts{
-				Endpoint: "https://backup4.cloudavenue.orange-business.com/NetBackupSelfService/Api",
+				Endpoint: testNetbackupEndpoint,
 			},
 			expectedUser: "",
 			expectedPass: "",

--- a/pkg/urn/urn_common_test.go
+++ b/pkg/urn/urn_common_test.go
@@ -18,6 +18,8 @@ const (
 	testInvalidUserURN     = "urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d479"
 	testInvalidUserURNLong = "urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791"
 	testExtractUUID        = "123e4567-e89b-12d3-a456-426614174000"
+	testIsCatalogName      = "IsCatalog"
+	testIsNotCatalogName   = "IsNotCatalog"
 )
 
 func TestNormalize(t *testing.T) {

--- a/pkg/urn/urn_common_test.go
+++ b/pkg/urn/urn_common_test.go
@@ -11,6 +11,15 @@ package urn
 
 import "testing"
 
+const (
+	testEmptyStringName    = "EmptyString"
+	testInvalidVMURN       = "urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	testInvalidVMURNLong   = "urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"
+	testInvalidUserURN     = "urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	testInvalidUserURNLong = "urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791"
+	testExtractUUID        = "123e4567-e89b-12d3-a456-426614174000"
+)
+
 func TestNormalize(t *testing.T) {
 	type args struct {
 		prefix URN
@@ -65,8 +74,8 @@ func TestExtractUUID(t *testing.T) {
 	}{
 		{
 			name:  "ValidUUID",
-			input: "This is a string with a UUID 123e4567-e89b-12d3-a456-426614174000 inside",
-			want:  "123e4567-e89b-12d3-a456-426614174000",
+			input: "This is a string with a UUID " + testExtractUUID + " inside",
+			want:  testExtractUUID,
 		},
 		{
 			name:  "NoUUID",
@@ -75,23 +84,23 @@ func TestExtractUUID(t *testing.T) {
 		},
 		{
 			name:  "ValidUUIDInURN",
-			input: "urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000",
-			want:  "123e4567-e89b-12d3-a456-426614174000",
+			input: "urn:vcloud:vm:" + testExtractUUID,
+			want:  testExtractUUID,
 		},
 		{
 			name:  "ValidUUID in URL",
-			input: "https://example.com/123e4567-e89b-12d3-a456-426614174000",
-			want:  "123e4567-e89b-12d3-a456-426614174000",
+			input: "https://example.com/" + testExtractUUID,
+			want:  testExtractUUID,
 		},
 		{
 			name:  "ValidUUID in URL with URN format",
-			input: "https://example.com/urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000",
-			want:  "123e4567-e89b-12d3-a456-426614174000",
+			input: "https://example.com/urn:vcloud:vm:" + testExtractUUID,
+			want:  testExtractUUID,
 		},
 		{
 			name:  "ValidUUID in URL with URN format and query",
-			input: "https://example.com/urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000?page=10",
-			want:  "123e4567-e89b-12d3-a456-426614174000",
+			input: "https://example.com/urn:vcloud:vm:" + testExtractUUID + "?page=10",
+			want:  testExtractUUID,
 		},
 		{
 			name:  "InvalidUUIDFormat",
@@ -99,7 +108,7 @@ func TestExtractUUID(t *testing.T) {
 			want:  "",
 		},
 		{
-			name:  "EmptyString",
+			name:  testEmptyStringName,
 			input: "",
 			want:  "",
 		},

--- a/pkg/urn/urn_is_funcs_test.go
+++ b/pkg/urn/urn_is_funcs_test.go
@@ -593,12 +593,12 @@ func TestIsCatalog(t *testing.T) {
 		want    bool
 	}{
 		{ // IsCatalog
-			name: "IsCatalog",
+			name: testIsCatalogName,
 			urn:  URN(Catalog.String() + validUUIDv4).String(),
 			want: true,
 		},
 		{ // IsNotCatalog
-			name: "IsNotCatalog",
+			name: testIsNotCatalogName,
 			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},

--- a/pkg/urn/urn_is_funcs_test.go
+++ b/pkg/urn/urn_is_funcs_test.go
@@ -25,11 +25,11 @@ func TestIsGroup(t *testing.T) {
 		},
 		{
 			name: "IsNotGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -58,11 +58,11 @@ func TestIsEdgeGateway(t *testing.T) {
 		},
 		{
 			name: "IsNotGateway",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -91,11 +91,11 @@ func TestIsVDC(t *testing.T) {
 		},
 		{
 			name: "IsNotVDC",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -124,11 +124,11 @@ func TestIsVDCGroup(t *testing.T) {
 		},
 		{
 			name: "IsNotVDCGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -157,11 +157,11 @@ func TestIsNetwork(t *testing.T) {
 		},
 		{
 			name: "IsNotNetwork",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -191,11 +191,11 @@ func TestIsLoadBalancerPool(t *testing.T) {
 		},
 		{ // IsNotLoadBalancerPool
 			name: "IsNotLoadBalancerPool",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -225,11 +225,11 @@ func TestIsVDCStorageProfile(t *testing.T) {
 		},
 		{ // IsNotVDCStorageProfile
 			name: "IsNotVDCStorageProfile",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -259,11 +259,11 @@ func TestIsVAPP(t *testing.T) {
 		},
 		{ // IsNotVAPP
 			name: "IsNotVAPP",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -293,11 +293,11 @@ func TestIsDisk(t *testing.T) {
 		},
 		{ // IsNotDisk
 			name: "IsNotDisk",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -327,11 +327,11 @@ func TestIsSecurityGroup(t *testing.T) {
 		},
 		{ // IsNotSecurityGroup
 			name: "IsNotSecurityGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -361,11 +361,11 @@ func TestIsVCDA(t *testing.T) {
 		},
 		{ // IsNotVCDA
 			name: "IsNotVCDA",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -395,11 +395,11 @@ func TestIsVM(t *testing.T) {
 		},
 		{ // IsNotVM
 			name: "IsNotVM",
-			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidUserURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -429,11 +429,11 @@ func TestIsUser(t *testing.T) {
 		},
 		{ // IsNotUser
 			name: "IsNotUser",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -463,11 +463,11 @@ func TestIsOrg(t *testing.T) {
 		},
 		{ // IsNotOrg
 			name: "IsNotOrg",
-			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidUserURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -497,11 +497,11 @@ func TestIsToken(t *testing.T) {
 		},
 		{ // IsNotToken
 			name: "IsNotToken",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			urn:  URN(testInvalidVMURNLong).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -531,11 +531,11 @@ func TestIsAppPortProfile(t *testing.T) {
 		},
 		{ // IsNotAppPortProfile
 			name: "IsNotAppPortProfile",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -565,11 +565,11 @@ func TestIsVDCComputePolicy(t *testing.T) {
 		},
 		{ // IsNotVDCComputePolicy
 			name: "IsNotVDCComputePolicy",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -599,11 +599,11 @@ func TestIsCatalog(t *testing.T) {
 		},
 		{ // IsNotCatalog
 			name: "IsNotCatalog",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -633,11 +633,11 @@ func TestIsVAPPTemplate(t *testing.T) {
 		},
 		{ // IsNotVAPPTemplate
 			name: "IsNotVAPPTemplate",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -667,11 +667,11 @@ func TestIsCertificateLibraryItem(t *testing.T) {
 		},
 		{ // IsNotCertificateLibraryItem
 			name: "IsNotCertificateLibraryItem",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -701,11 +701,11 @@ func TestIsLoadBalancerVirtualService(t *testing.T) {
 		},
 		{ // IsNotLoadBalancerVirtualService
 			name: "IsNotLoadBalancerVirtualService",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},
@@ -735,11 +735,11 @@ func TestIsServiceEngineGroup(t *testing.T) {
 		},
 		{ // IsNotServiceEngineGroup
 			name: "IsNotServiceEngineGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			urn:  URN(testInvalidVMURN).String(),
 			want: false,
 		},
 		{ // EmptyString
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN("").String(),
 			want: false,
 		},

--- a/pkg/urn/urn_is_methods_test.go
+++ b/pkg/urn/urn_is_methods_test.go
@@ -24,11 +24,11 @@ func TestURN_IsVM(t *testing.T) {
 		},
 		{
 			name: "IsNotVM",
-			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidUserURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -55,11 +55,11 @@ func TestURN_IsUser(t *testing.T) {
 		},
 		{
 			name: "IsNotUser",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -87,11 +87,11 @@ func TestURN_IsGroup(t *testing.T) {
 		},
 		{
 			name: "IsNotGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -119,11 +119,11 @@ func TestURN_IsGateway(t *testing.T) {
 		},
 		{
 			name: "IsNotGateway",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -151,11 +151,11 @@ func TestURN_IsAppPortProfile(t *testing.T) {
 		},
 		{ // IsNotAppProfile
 			name: "IsNotAppProfile",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -183,11 +183,11 @@ func TestURN_IsVDC(t *testing.T) {
 		},
 		{
 			name: "IsNotVDC",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -215,11 +215,11 @@ func TestURN_IsVDCGroup(t *testing.T) {
 		},
 		{ // IsNotVDCGroup
 			name: "IsNotVDCGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -247,11 +247,11 @@ func TestURN_IsNetwork(t *testing.T) {
 		},
 		{
 			name: "IsNotNetwork",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -279,11 +279,11 @@ func TestURN_IsLoadBalancerPool(t *testing.T) {
 		},
 		{
 			name: "IsNotLoadBalancerPool",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -311,11 +311,11 @@ func TestURN_IsVDCStorageProfile(t *testing.T) {
 		},
 		{
 			name: "IsNotVDCStorageProfile",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -343,11 +343,11 @@ func TestURN_IsVAPP(t *testing.T) {
 		},
 		{
 			name: "IsNotVAPP",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -375,11 +375,11 @@ func TestURN_IsDisk(t *testing.T) {
 		},
 		{
 			name: "IsNotDisk",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -407,11 +407,11 @@ func TestURN_IsSecurityGroup(t *testing.T) {
 		},
 		{
 			name: "IsNotSecurityGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			urn:  URN(testInvalidVMURN),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -439,11 +439,11 @@ func TestURN_IsVAPPTemplate(t *testing.T) {
 		},
 		{ // IsNotVAPPTemplate
 			name: "IsNotVAPPTemplate",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -471,11 +471,11 @@ func TestURN_IsCatalog(t *testing.T) {
 		},
 		{ // IsNotCatalog
 			name: "IsNotCatalog",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -503,11 +503,11 @@ func TestURN_IsToken(t *testing.T) {
 		},
 		{ // IsNotToken
 			name: "IsNotToken",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -535,11 +535,11 @@ func TestVcloudURN_IsCatalog(t *testing.T) {
 		},
 		{ // IsNotCatalog
 			name: "IsNotCatalog",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -567,11 +567,11 @@ func TestURN_IsOrg(t *testing.T) {
 		},
 		{ // IsNotOrg
 			name: "IsNotOrg",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -599,11 +599,11 @@ func TestURN_IsVDCComputePolicy(t *testing.T) {
 		},
 		{ // IsNotVDCComputePolicy
 			name: "IsNotVDCComputePolicy",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -631,11 +631,11 @@ func TestURN_IsLoadBalancerVirtualService(t *testing.T) {
 		},
 		{ // IsNotLoadBalancerVirtualService
 			name: "IsNotLoadBalancerVirtualService",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -663,11 +663,11 @@ func TestURN_IsCertificateLibraryItem(t *testing.T) {
 		},
 		{ // IsNotCertificateLibraryItem
 			name: "IsNotCertificateLibraryItem",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -695,11 +695,11 @@ func TestURN_IsServiceEngineGroup(t *testing.T) {
 		},
 		{ // IsNotServiceEngineGroup
 			name: "IsNotServiceEngineGroup",
-			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},

--- a/pkg/urn/urn_is_methods_test.go
+++ b/pkg/urn/urn_is_methods_test.go
@@ -465,12 +465,12 @@ func TestURN_IsCatalog(t *testing.T) {
 		want bool
 	}{
 		{ // IsCatalog
-			name: "IsCatalog",
+			name: testIsCatalogName,
 			urn:  URN(Catalog.String() + validUUIDv4),
 			want: true,
 		},
 		{ // IsNotCatalog
-			name: "IsNotCatalog",
+			name: testIsNotCatalogName,
 			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},
@@ -529,12 +529,12 @@ func TestVcloudURN_IsCatalog(t *testing.T) {
 		want bool
 	}{
 		{ // IsCatalog
-			name: "IsCatalog",
+			name: testIsCatalogName,
 			urn:  URN(Catalog.String() + validUUIDv4),
 			want: true,
 		},
 		{ // IsNotCatalog
-			name: "IsNotCatalog",
+			name: testIsNotCatalogName,
 			urn:  URN(testInvalidVMURNLong),
 			want: false,
 		},

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -34,7 +34,7 @@ func TestURN_ContainsPrefix(t *testing.T) {
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			want: false,
 		},
@@ -72,7 +72,7 @@ func Test_isURNV4(t *testing.T) {
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			args: args{
 				urn: "",
 			},
@@ -115,7 +115,7 @@ func TestURN_IsType(t *testing.T) {
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  URN(""),
 			args: args{
 				prefix: VM,
@@ -151,7 +151,7 @@ func Test_extractURNv4(t *testing.T) {
 			want: validUUIDv4,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			args: args{
 				urn:    "",
 				prefix: VM,
@@ -199,7 +199,7 @@ func TestIsValid(t *testing.T) {
 			want: false,
 		},
 		{ // Empty string
-			name: "EmptyString",
+			name: testEmptyStringName,
 			args: args{
 				urn: "",
 			},
@@ -275,7 +275,7 @@ func TestIsUUIDV4(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "EmptyString",
+			name: testEmptyStringName,
 			urn:  "",
 			want: false,
 		},

--- a/v1/edgegateway/edgegateway_test.go
+++ b/v1/edgegateway/edgegateway_test.go
@@ -30,6 +30,24 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
+const (
+	testSuccess            = "success"
+	testEdgeGatewayName    = "test-edge-gateway"
+	testEdgeGatewayDesc    = "test description"
+	testEdgeGatewayStatus  = "ACTIVE"
+	testVDCName            = "test-vdc"
+	testVRFName            = "prvrf01eocb0009999allsp01"
+	testEdgeID             = "edge-id"
+	testIPAddress          = "12.123.123.12"
+	testServiceName        = "tn99e99ocb0009999spt199-cav-services"
+	testServiceDisplayName = "Cloud Avenue Services"
+	testEdgeGatewayName2   = "test-edge-gateway-2"
+	testEdgeGatewayDesc2   = "test description 2"
+	testJobID              = "job-id"
+	testErrorGetJobStatus  = "error-get-job-status"
+	testServiceID          = "service-id"
+)
+
 func TestClient_GetEdgeGateway(t *testing.T) {
 	// Mock controller.
 	ctrl := gomock.NewController(t)
@@ -53,23 +71,23 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 		err                 error
 	}{
 		{
-			name:                "success",
+			name:                testSuccess,
 			edgeGatewayNameOrID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -82,7 +100,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				// mock getNetworkServices
@@ -157,14 +175,14 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 			},
 			expectedEdgeGateway: &EdgeGatewayModel{
 				ID:          edgeGatewayID,
-				Name:        "test-edge-gateway",
-				Description: "test description",
+				Name:        testEdgeGatewayName,
+				Description: testEdgeGatewayDesc,
 				OwnerRef: &govcdtypes.OpenApiReference{
 					ID:   vdcID,
-					Name: "test-vdc",
+					Name: testVDCName,
 				},
-				Status:    "ACTIVE",
-				UplinkT0:  "prvrf01eocb0009999allsp01",
+				Status:    testEdgeGatewayStatus,
+				UplinkT0:  testVRFName,
 				Bandwidth: 10,
 				Services: NetworkServicesModelSvcs{
 					LoadBalancer: &NetworkServicesModelSvcLoadBalancer{
@@ -179,16 +197,16 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						{
 							NetworkServicesModelSvc: NetworkServicesModelSvc{
 								ID:   "ip-12-123-123-12",
-								Name: "12.123.123.12",
+								Name: testIPAddress,
 							},
-							IP:        "12.123.123.12",
+							IP:        testIPAddress,
 							Announced: true,
 						},
 					},
 					Service: &NetworkServicesModelSvcService{
 						NetworkServicesModelSvc: NetworkServicesModelSvc{
-							ID:   "tn99e99ocb0009999spt199-cav-services",
-							Name: "Cloud Avenue Services",
+							ID:   testServiceName,
+							Name: testServiceDisplayName,
 						},
 						Network:               "100.113.99.96/27",
 						DedicatedIPForService: "100.113.99.96",
@@ -200,22 +218,22 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 		},
 		{
 			name:                "success-by-name",
-			edgeGatewayNameOrID: "test-edge-gateway",
+			edgeGatewayNameOrID: testEdgeGatewayName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
-				clientCAV.EXPECT().GetNsxtEdgeGatewayByName("test-edge-gateway").Return(&govcd.NsxtEdgeGateway{
+				clientCAV.EXPECT().GetNsxtEdgeGatewayByName(testEdgeGatewayName).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -228,7 +246,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				// mock getNetworkServices
@@ -303,14 +321,14 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 			},
 			expectedEdgeGateway: &EdgeGatewayModel{
 				ID:          edgeGatewayID,
-				Name:        "test-edge-gateway",
-				Description: "test description",
+				Name:        testEdgeGatewayName,
+				Description: testEdgeGatewayDesc,
 				OwnerRef: &govcdtypes.OpenApiReference{
 					ID:   vdcID,
-					Name: "test-vdc",
+					Name: testVDCName,
 				},
-				Status:    "ACTIVE",
-				UplinkT0:  "prvrf01eocb0009999allsp01",
+				Status:    testEdgeGatewayStatus,
+				UplinkT0:  testVRFName,
 				Bandwidth: 10,
 				Services: NetworkServicesModelSvcs{
 					LoadBalancer: &NetworkServicesModelSvcLoadBalancer{
@@ -325,16 +343,16 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						{
 							NetworkServicesModelSvc: NetworkServicesModelSvc{
 								ID:   "ip-12-123-123-12",
-								Name: "12.123.123.12",
+								Name: testIPAddress,
 							},
-							IP:        "12.123.123.12",
+							IP:        testIPAddress,
 							Announced: true,
 						},
 					},
 					Service: &NetworkServicesModelSvcService{
 						NetworkServicesModelSvc: NetworkServicesModelSvc{
-							ID:   "tn99e99ocb0009999spt199-cav-services",
-							Name: "Cloud Avenue Services",
+							ID:   testServiceName,
+							Name: testServiceDisplayName,
 						},
 						Network:               "100.113.99.96/27",
 						DedicatedIPForService: "100.113.99.96",
@@ -381,12 +399,12 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 					},
 				}, nil)
@@ -398,7 +416,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -420,12 +438,12 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 					},
 				}, nil)
@@ -437,7 +455,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -463,19 +481,19 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 					},
 				}, nil)
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
 					responder := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -491,12 +509,12 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 					},
 				}, nil)
@@ -507,7 +525,7 @@ func TestClient_GetEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -560,31 +578,31 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 		err                 error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetAllNsxtEdgeGateways(nil).Return([]*govcd.NsxtEdgeGateway{
 					{
 						EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 							ID:          edgeGatewayID,
-							Name:        "test-edge-gateway",
-							Description: "test description",
-							Status:      "ACTIVE",
+							Name:        testEdgeGatewayName,
+							Description: testEdgeGatewayDesc,
+							Status:      testEdgeGatewayStatus,
 							OwnerRef: &govcdtypes.OpenApiReference{
 								ID:   vdcID,
-								Name: "test-vdc",
+								Name: testVDCName,
 							},
 						},
 					},
 					{
 						EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 							ID:          edgeGatewayID2,
-							Name:        "test-edge-gateway-2",
-							Description: "test description 2",
-							Status:      "ACTIVE",
+							Name:        testEdgeGatewayName2,
+							Description: testEdgeGatewayDesc2,
+							Status:      testEdgeGatewayStatus,
 							OwnerRef: &govcdtypes.OpenApiReference{
 								ID:   vdcID,
-								Name: "test-vdc",
+								Name: testVDCName,
 							},
 						},
 					},
@@ -597,7 +615,7 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				// mock getBandwidth test-edge-gateway-2
@@ -608,30 +626,30 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID2)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID2)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
 			expectedEdgeGateway: []*EdgeGatewayModel{
 				{
 					ID:          edgeGatewayID,
-					Name:        "test-edge-gateway",
-					Description: "test description",
-					Status:      "ACTIVE",
+					Name:        testEdgeGatewayName,
+					Description: testEdgeGatewayDesc,
+					Status:      testEdgeGatewayStatus,
 					OwnerRef: &govcdtypes.OpenApiReference{
 						ID:   vdcID,
-						Name: "test-vdc",
+						Name: testVDCName,
 					},
 					Bandwidth: 10,
 				},
 				{
 					ID:          edgeGatewayID2,
-					Name:        "test-edge-gateway-2",
-					Description: "test description 2",
-					Status:      "ACTIVE",
+					Name:        testEdgeGatewayName2,
+					Description: testEdgeGatewayDesc2,
+					Status:      testEdgeGatewayStatus,
 					OwnerRef: &govcdtypes.OpenApiReference{
 						ID:   vdcID,
-						Name: "test-vdc",
+						Name: testVDCName,
 					},
 					Bandwidth: 100,
 				},
@@ -665,24 +683,24 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 					{
 						EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 							ID:          edgeGatewayID,
-							Name:        "test-edge-gateway",
-							Description: "test description",
-							Status:      "ACTIVE",
+							Name:        testEdgeGatewayName,
+							Description: testEdgeGatewayDesc,
+							Status:      testEdgeGatewayStatus,
 							OwnerRef: &govcdtypes.OpenApiReference{
 								ID:   vdcID,
-								Name: "test-vdc",
+								Name: testVDCName,
 							},
 						},
 					},
 					{
 						EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 							ID:          edgeGatewayID2,
-							Name:        "test-edge-gateway-2",
-							Description: "test description 2",
-							Status:      "ACTIVE",
+							Name:        testEdgeGatewayName2,
+							Description: testEdgeGatewayDesc2,
+							Status:      testEdgeGatewayStatus,
 							OwnerRef: &govcdtypes.OpenApiReference{
 								ID:   vdcID,
-								Name: "test-vdc",
+								Name: testVDCName,
 							},
 						},
 					},
@@ -695,7 +713,7 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 
@@ -703,7 +721,7 @@ func TestClient_ListEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
 					responder := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID2)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID2)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -792,7 +810,7 @@ func TestClient_UpdateEdgeGateway(t *testing.T) {
 		err           error
 	}{
 		{
-			name:   "success",
+			name:   testSuccess,
 			edgeID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -807,7 +825,7 @@ func TestClient_UpdateEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("PUT", endpoints.InlineTemplate(endpoints.EdgeGatewayUpdate, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("PUT", endpoints.InlineTemplate(endpoints.EdgeGatewayUpdate, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 
 					// * mock getJobStatus
 					responderJob, err := httpmock.NewJsonResponder(200, json.RawMessage(`[{"actions":[],"description":"string","name":"string","status":"DONE"}]`))
@@ -815,7 +833,7 @@ func TestClient_UpdateEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -843,7 +861,7 @@ func TestClient_UpdateEdgeGateway(t *testing.T) {
 
 					// * mock getBandwidth
 					responder := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("PUT", endpoints.InlineTemplate(endpoints.EdgeGatewayUpdate, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("PUT", endpoints.InlineTemplate(endpoints.EdgeGatewayUpdate, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -926,7 +944,7 @@ func TestClient_EnableNetworkService(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 
 					return clientcloudavenue.MockClient().R()
 				})
@@ -1038,7 +1056,7 @@ func TestClient_EnableNetworkService(t *testing.T) {
 			err:           fmt.Errorf("error"),
 		},
 		{
-			name: "error-get-job-status",
+			name: testErrorGetJobStatus,
 			mockFunc: func() {
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
@@ -1053,7 +1071,7 @@ func TestClient_EnableNetworkService(t *testing.T) {
 
 					// * mock getJobStatus
 					responderJob := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 
 					return clientcloudavenue.MockClient().R()
 				})
@@ -1069,10 +1087,10 @@ func TestClient_EnableNetworkService(t *testing.T) {
 
 			e.EdgeGatewayModel = &EdgeGatewayModel{
 				ID:   edgeGatewayID,
-				Name: "test-edge-gateway",
+				Name: testEdgeGatewayName,
 				OwnerRef: &govcdtypes.OpenApiReference{
 					ID:   vdcID,
-					Name: "test-vdc",
+					Name: testVDCName,
 				},
 			}
 
@@ -1120,7 +1138,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{"service-id": "tn99e99ocb0009999spt199-cav-services"}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{testServiceID: testServiceName}), responder)
 
 					// * mock getJobStatus
 					responderJob, err := httpmock.NewJsonResponder(200, json.RawMessage(`[{"actions":[],"description":"string","name":"string","status":"DONE"}]`))
@@ -1128,7 +1146,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 					return clientcloudavenue.MockClient().R()
 				})
 
@@ -1211,7 +1229,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 
 					// * mock disableNetworkService
 					responder := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{"service-id": "tn99e99ocb0009999spt199-cav-services"}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{testServiceID: testServiceName}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -1230,7 +1248,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{"service-id": "tn99e99ocb0009999spt199-cav-services"}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{testServiceID: testServiceName}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -1238,7 +1256,7 @@ func TestClient_DisableNetworkService(t *testing.T) {
 			err:           fmt.Errorf("error"),
 		},
 		{
-			name: "error-get-job-status",
+			name: testErrorGetJobStatus,
 			mockFunc: func() {
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
 					httpmock.ActivateNonDefault(clientcloudavenue.MockClient().GetClient())
@@ -1249,11 +1267,11 @@ func TestClient_DisableNetworkService(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{"service-id": "tn99e99ocb0009999spt199-cav-services"}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{testServiceID: testServiceName}), responder)
 
 					// * mock getJobStatus
 					responderJob := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 
 					return clientcloudavenue.MockClient().R()
 				})
@@ -1269,16 +1287,16 @@ func TestClient_DisableNetworkService(t *testing.T) {
 
 			e.EdgeGatewayModel = &EdgeGatewayModel{
 				ID:   edgeGatewayID,
-				Name: "test-edge-gateway",
+				Name: testEdgeGatewayName,
 				OwnerRef: &govcdtypes.OpenApiReference{
 					ID:   vdcID,
-					Name: "test-vdc",
+					Name: testVDCName,
 				},
 				Services: NetworkServicesModelSvcs{
 					Service: &NetworkServicesModelSvcService{
 						NetworkServicesModelSvc: NetworkServicesModelSvc{
-							ID:   "tn99e99ocb0009999spt199-cav-services",
-							Name: "Cloud Avenue Services",
+							ID:   testServiceName,
+							Name: testServiceDisplayName,
 						},
 					},
 				},
@@ -1323,16 +1341,16 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -1345,7 +1363,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -1357,7 +1375,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 
 					// * mock getJobStatus
 					responderJob, err := httpmock.NewJsonResponder(200, json.RawMessage(`[{"actions":[],"description":"string","name":"string","status":"DONE"}]`))
@@ -1365,7 +1383,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -1378,16 +1396,16 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -1400,7 +1418,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -1411,7 +1429,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -1425,16 +1443,16 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -1447,7 +1465,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -1455,7 +1473,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 
 					// * mock deleteEdgeGateway
 					responder := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 			},
@@ -1463,22 +1481,22 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 			err:           fmt.Errorf("error"),
 		},
 		{
-			name: "error-get-job-status",
+			name: testErrorGetJobStatus,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetNsxtEdgeGatewayById(edgeGatewayID).Return(&govcd.NsxtEdgeGateway{
 					EdgeGateway: &govcdtypes.OpenAPIEdgeGateway{
 						ID:          edgeGatewayID,
-						Name:        "test-edge-gateway",
-						Description: "test description",
-						Status:      "ACTIVE",
+						Name:        testEdgeGatewayName,
+						Description: testEdgeGatewayDesc,
+						Status:      testEdgeGatewayStatus,
 						OwnerRef: &govcdtypes.OpenApiReference{
 							ID:   vdcID,
-							Name: "test-vdc",
+							Name: testVDCName,
 						},
 						EdgeGatewayUplinks: []govcdtypes.EdgeGatewayUplinks{
 							{
-								UplinkName: "prvrf01eocb0009999allsp01",
+								UplinkName: testVRFName,
 							},
 						},
 					},
@@ -1491,7 +1509,7 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.EdgeGatewayGet, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 					return clientcloudavenue.MockClient().R()
 				})
 				clientCAV.EXPECT().R().DoAndReturn(func() *resty.Request {
@@ -1503,11 +1521,11 @@ func TestClient_DeleteEdgeGateway(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{"edge-id": urn.ExtractUUID(edgeGatewayID)}), responder)
+					httpmock.RegisterResponder("DELETE", endpoints.InlineTemplate(endpoints.EdgeGatewayDelete, map[string]string{testEdgeID: urn.ExtractUUID(edgeGatewayID)}), responder)
 
 					// * mock getJobStatus
 					responderJob := httpmock.NewErrorResponder(fmt.Errorf("error"))
-					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{"job-id": jobStatusID}), responderJob)
+					httpmock.RegisterResponder("GET", endpoints.InlineTemplate(endpoints.JobStatusGet, map[string]string{testJobID: jobStatusID}), responderJob)
 
 					return clientcloudavenue.MockClient().R()
 				})

--- a/v1/edgegateway/services.go
+++ b/v1/edgegateway/services.go
@@ -19,6 +19,8 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
+const serviceIDKey = "service-id"
+
 func (e *EdgeGateway) getNetworkServices(ctx context.Context) error {
 	// Clean up the previous services
 	e.EdgeGatewayModel.Services = NetworkServicesModelSvcs{
@@ -176,7 +178,7 @@ func (e *EdgeGateway) DisableNetworkService(ctx context.Context) error {
 		SetContext(ctx).
 		SetResult(&commoncloudavenue.JobStatus{}).
 		Delete(endpoints.InlineTemplate(endpoints.NetworkServiceDelete, map[string]string{
-			"service-id": e.EdgeGatewayModel.Services.Service.ID,
+			serviceIDKey: e.EdgeGatewayModel.Services.Service.ID,
 		}))
 	if err != nil {
 		return fmt.Errorf("error disabling network services: %w", err)

--- a/v1/edgegateway/services_available.go
+++ b/v1/edgegateway/services_available.go
@@ -9,6 +9,11 @@
 
 package edgegateway
 
+const (
+	serviceProtocolTCP = "tcp"
+	serviceProtocolUDP = "udp"
+)
+
 type (
 	ServiceModel struct {
 		IPAllocated string
@@ -53,7 +58,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     3142,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},
@@ -65,7 +70,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     8080,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},
@@ -77,11 +82,11 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     8530,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 					{
 						Port:     8531,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},
@@ -95,7 +100,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     1688,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},
@@ -113,7 +118,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     123,
-						Protocol: "udp",
+						Protocol: serviceProtocolUDP,
 					},
 				},
 			},
@@ -129,11 +134,11 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     53,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 					{
 						Port:     53,
-						Protocol: "udp",
+						Protocol: serviceProtocolUDP,
 					},
 				},
 			},
@@ -149,11 +154,11 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     53,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 					{
 						Port:     53,
-						Protocol: "udp",
+						Protocol: serviceProtocolUDP,
 					},
 				},
 			},
@@ -168,7 +173,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     25,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},
@@ -189,7 +194,7 @@ var ListOfServices = []ServiceModelDetails{
 				Ports: []NetworkServicesModelSvcServiceDetailsPorts{
 					{
 						Port:     443,
-						Protocol: "tcp",
+						Protocol: serviceProtocolTCP,
 					},
 				},
 			},

--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -23,6 +23,8 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
+const edgeIDKey = "EdgeID"
+
 type (
 	EdgeGateway struct{}
 	OwnerType   string
@@ -199,7 +201,7 @@ func (v *EdgeGateway) Get(edgeGatewayNameOrID string) (edgeClient *EdgeClient, e
 				SetResult(&EdgeGatewayType{}).
 				SetError(&commoncloudavenue.APIErrorResponse{}).
 				SetPathParams(map[string]string{
-					"EdgeID": strings.TrimPrefix(nameOrID.String(), urn.Gateway.String()),
+					edgeIDKey: strings.TrimPrefix(nameOrID.String(), urn.Gateway.String()),
 				}).
 				Get("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 			if err != nil {
@@ -260,7 +262,7 @@ func (e *EdgeGatewayType) Delete() (job *commoncloudavenue.JobStatus, err error)
 		SetResult(&commoncloudavenue.JobStatus{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParams(map[string]string{
-			"EdgeID": e.EdgeID,
+			edgeIDKey: e.EdgeID,
 		}).
 		Delete("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
@@ -295,7 +297,7 @@ func (e *EdgeGatewayType) UpdateBandwidth(rateLimit int) (job *commoncloudavenue
 			"rateLimit": rateLimit,
 		}).
 		SetPathParams(map[string]string{
-			"EdgeID": e.EdgeID,
+			edgeIDKey: e.EdgeID,
 		}).
 		Put("/infrapicustomerproxy/v2.0/edges/{EdgeID}")
 	if err != nil {
@@ -361,7 +363,7 @@ func (n NetworkType) GetEndAddress() string {
 	broadcast := numIPs - 1
 	end := make(net.IP, 4)
 	for i := 0; i < 4; i++ {
-		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //nolint:gosec
+		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff)
 	}
 
 	return end.String()
@@ -422,7 +424,7 @@ func (e *EdgeGatewayType) ListNetworksType() (response *NetworkTypes, err error)
 		SetResult(&NetworkTypes{}).
 		SetError(&commoncloudavenue.APIErrorResponse{}).
 		SetPathParams(map[string]string{
-			"EdgeID": e.EdgeID,
+			edgeIDKey: e.EdgeID,
 		}).
 		Get("/infrapicustomerproxy/v2.0/edges/{EdgeID}/networks")
 	if err != nil {

--- a/v1/edgeloadbalancer/policies_http_request_test.go
+++ b/v1/edgeloadbalancer/policies_http_request_test.go
@@ -49,7 +49,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 		err              error
 	}{
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -60,7 +60,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -77,7 +77,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -95,7 +95,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -103,22 +103,22 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -130,7 +130,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -138,7 +138,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -147,7 +147,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -157,7 +157,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								KeepQuery:  true,
 								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
-								Protocol:   "HTTP",
+								Protocol:   string(PoliciesHTTPProtocolHTTP),
 								StatusCode: 301,
 							},
 						},
@@ -172,32 +172,32 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -218,7 +218,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -235,7 +235,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -252,7 +252,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
-								Protocol:    "HTTP",
+								Protocol:    string(PoliciesHTTPProtocolHTTP),
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{},
 							},
 							RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
@@ -260,7 +260,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								KeepQuery:  true,
 								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
-								Protocol:   "HTTP",
+								Protocol:   string(PoliciesHTTPProtocolHTTP),
 								StatusCode: 301,
 							},
 						},
@@ -275,14 +275,14 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: string(PoliciesHTTPProtocolHTTP),
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -303,7 +303,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -320,7 +320,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -338,7 +338,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -346,22 +346,22 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -373,7 +373,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -381,7 +381,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -390,19 +390,19 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
-									Action: "ADD",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 									Name:   testHeaderXForwardedFor,
 									Value:  testHeaderValueTest,
 								},
 								{
-									Action: "REMOVE",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 									Name:   testHeaderXForwardedProto,
 									Value:  "",
 								},
@@ -424,34 +424,34 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
-								Action: "ADD",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 								Name:   testHeaderXForwardedFor,
 								Value:  testHeaderValueTest,
 							},
 							{
-								Action: "REMOVE",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 								Name:   testHeaderXForwardedProto,
 								Value:  "",
 							},
@@ -479,7 +479,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -496,7 +496,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -603,7 +603,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 		err         error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			policies: &PoliciesHTTPRequestModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
@@ -612,32 +612,32 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -652,7 +652,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -669,7 +669,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -687,7 +687,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -695,22 +695,22 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -722,7 +722,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -730,7 +730,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -739,7 +739,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -749,7 +749,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								KeepQuery:  true,
 								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
-								Protocol:   "HTTP",
+								Protocol:   string(PoliciesHTTPProtocolHTTP),
 								StatusCode: 301,
 							},
 						},
@@ -772,7 +772,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
@@ -780,7 +780,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -795,7 +795,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -812,7 +812,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -830,7 +830,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -838,22 +838,22 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -865,7 +865,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -873,7 +873,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -882,7 +882,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -892,7 +892,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								KeepQuery:  true,
 								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
-								Protocol:   "HTTP",
+								Protocol:   string(PoliciesHTTPProtocolHTTP),
 								StatusCode: 301,
 							},
 						},
@@ -915,7 +915,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						URLRewriteAction: &PoliciesHTTPActionURLRewrite{
@@ -935,7 +935,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -952,7 +952,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -970,7 +970,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -978,22 +978,22 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -1005,7 +1005,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -1013,7 +1013,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -1022,7 +1022,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -1052,32 +1052,32 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -1098,32 +1098,32 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -1145,32 +1145,32 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -1193,32 +1193,32 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
 							Host:       testDomain,
 							KeepQuery:  true,
 							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							StatusCode: 301,
 						},
 					},
@@ -1278,7 +1278,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 		err              error
 	}{
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1289,7 +1289,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1306,7 +1306,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},

--- a/v1/edgeloadbalancer/policies_http_request_test.go
+++ b/v1/edgeloadbalancer/policies_http_request_test.go
@@ -56,8 +56,8 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -81,7 +81,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -90,16 +90,16 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -120,42 +120,42 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
-								Path:       "/newpath",
+								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
 								Protocol:   "HTTP",
 								StatusCode: 301,
@@ -168,34 +168,34 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -214,8 +214,8 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -239,7 +239,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -248,7 +248,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
@@ -256,9 +256,9 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{},
 							},
 							RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
-								Path:       "/newpath",
+								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
 								Protocol:   "HTTP",
 								StatusCode: 301,
@@ -271,16 +271,16 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol: "HTTP",
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -299,8 +299,8 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -324,7 +324,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -333,16 +333,16 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -363,53 +363,53 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
 									Action: "ADD",
-									Name:   "X-Forwarded-For",
-									Value:  "test",
+									Name:   testHeaderXForwardedFor,
+									Value:  testHeaderValueTest,
 								},
 								{
 									Action: "REMOVE",
-									Name:   "X-Forwarded-Proto",
+									Name:   testHeaderXForwardedProto,
 									Value:  "",
 								},
 							},
 							RewriteURLAction: &govcdtypes.AlbVsHttpRequestRuleRewriteURLAction{
-								Host:      "example.com",
-								Path:      "/newpath",
+								Host:      testDomain,
+								Path:      testNewPath,
 								KeepQuery: true,
 							},
 						},
@@ -420,45 +420,45 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
 								Action: "ADD",
-								Name:   "X-Forwarded-For",
-								Value:  "test",
+								Name:   testHeaderXForwardedFor,
+								Value:  testHeaderValueTest,
 							},
 							{
 								Action: "REMOVE",
-								Name:   "X-Forwarded-Proto",
+								Name:   testHeaderXForwardedProto,
 								Value:  "",
 							},
 						},
 						URLRewriteAction: &PoliciesHTTPActionURLRewrite{
-							HostHeader: "example.com",
-							Path:       "/newpath",
+							HostHeader: testDomain,
+							Path:       testNewPath,
 							KeepQuery:  true,
 						},
 					},
@@ -475,8 +475,8 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -500,7 +500,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -518,7 +518,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -527,7 +527,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -535,7 +535,7 @@ func TestClient_GetPoliciesHTTPRequest(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -608,34 +608,34 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -648,8 +648,8 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -673,7 +673,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -682,16 +682,16 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -712,42 +712,42 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
-								Path:       "/newpath",
+								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
 								Protocol:   "HTTP",
 								StatusCode: 301,
@@ -768,17 +768,17 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:   "HTTP",
-							QueryMatch: []string{"key1=value1", "key2=value2"},
+							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -791,8 +791,8 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -816,7 +816,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -825,16 +825,16 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -855,42 +855,42 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
-								Path:       "/newpath",
+								Path:       testNewPath,
 								Port:       utils.ToPTR(80),
 								Protocol:   "HTTP",
 								StatusCode: 301,
@@ -911,16 +911,16 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:   "HTTP",
-							QueryMatch: []string{"key1=value1", "key2=value2"},
+							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						URLRewriteAction: &PoliciesHTTPActionURLRewrite{
-							HostHeader: "example.com",
-							Path:       "/newpath",
+							HostHeader: testDomain,
+							Path:       testNewPath,
 							KeepQuery:  true,
 						},
 					},
@@ -931,8 +931,8 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -956,7 +956,7 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -965,16 +965,16 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				getPoliciesHTTPRequest = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpRequestRule, error) {
 					return []*govcdtypes.AlbVsHttpRequestRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -995,41 +995,41 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RewriteURLAction: &govcdtypes.AlbVsHttpRequestRuleRewriteURLAction{
-								Host:      "example.com",
-								Path:      "/newpath",
+								Host:      testDomain,
+								Path:      testNewPath,
 								KeepQuery: true,
 							},
 						},
@@ -1043,39 +1043,39 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name: "error-validation-model",
+			name: testErrorValidationModel,
 			policies: &PoliciesHTTPRequestModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -1088,40 +1088,40 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 			err:         errors.New("Error:Field validation"),
 		},
 		{
-			name:        "error-refresh",
+			name:        testErrorRefresh,
 			expectedErr: true,
 			policies: &PoliciesHTTPRequestModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -1135,40 +1135,40 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:        "error-getVirtualService",
+			name:        testErrorGetVS,
 			expectedErr: true,
 			policies: &PoliciesHTTPRequestModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -1189,34 +1189,34 @@ func TestClient_UpdatePoliciesHTTPRequest(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPRequestModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPRequestMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectAction: &PoliciesHTTPActionRedirect{
-							Host:       "example.com",
+							Host:       testDomain,
 							KeepQuery:  true,
-							Path:       "/newpath",
+							Path:       testNewPath,
 							Port:       utils.ToPTR(80),
 							Protocol:   "HTTP",
 							StatusCode: 301,
@@ -1285,8 +1285,8 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1310,7 +1310,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1324,7 +1324,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:             "error-delete",
+			name:             testErrorDelete,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1337,7 +1337,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 			err:         errors.New("error"),
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -1346,7 +1346,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -1354,7 +1354,7 @@ func TestClient_DeletePoliciesHTTPRequest(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {

--- a/v1/edgeloadbalancer/policies_http_response_test.go
+++ b/v1/edgeloadbalancer/policies_http_response_test.go
@@ -56,8 +56,8 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -81,7 +81,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -90,16 +90,16 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -120,62 +120,62 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "X-Custom-Header",
-										Value:         []string{"value1", "value2"},
+										Key:           testHeaderXCustom,
+										Value:         []string{testHeaderValue1, "value2"},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
 									MatchCriteria: "BEGINS_WITH",
 									Value: []string{
-										"example.com",
+										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
 									MatchCriteria: "IS_IN",
 									StatusCodes: []string{
 										"200",
-										"301-303",
+										testRedirectCode,
 									},
 								},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
-								Host:      "example.com",
+								Host:      testDomain,
 								KeepQuery: true,
-								Path:      "/newpath",
+								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
 								Protocol:  "HTTP",
 							},
@@ -187,43 +187,43 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -241,8 +241,8 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -266,7 +266,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -275,7 +275,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
@@ -283,9 +283,9 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
-								Host:      "example.com",
+								Host:      testDomain,
 								KeepQuery: true,
-								Path:      "/newpath",
+								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
 								Protocol:  "HTTP",
 							},
@@ -297,16 +297,16 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol: "HTTP",
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -324,8 +324,8 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -349,7 +349,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -358,16 +358,16 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -388,75 +388,75 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "X-Custom-Header",
-										Value:         []string{"value1", "value2"},
+										Key:           testHeaderXCustom,
+										Value:         []string{testHeaderValue1, "value2"},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
 									MatchCriteria: "BEGINS_WITH",
 									Value: []string{
-										"example.com",
+										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
 									MatchCriteria: "IS_IN",
 									StatusCodes: []string{
 										"200",
-										"301-303",
+										testRedirectCode,
 									},
 								},
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
 									Action: "ADD",
-									Name:   "X-Forwarded-For",
-									Value:  "test",
+									Name:   testHeaderXForwardedFor,
+									Value:  testHeaderValueTest,
 								},
 								{
 									Action: "REMOVE",
-									Name:   "X-Forwarded-Proto",
+									Name:   testHeaderXForwardedProto,
 									Value:  "",
 								},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
 								Protocol:  "HTTP",
-								Host:      "example.com",
+								Host:      testDomain,
 								Port:      utils.ToPTR(80),
-								Path:      "/newpath",
+								Path:      testNewPath,
 								KeepQuery: true,
 							},
 						},
@@ -467,56 +467,56 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
 								Action: "ADD",
-								Name:   "X-Forwarded-For",
-								Value:  "test",
+								Name:   testHeaderXForwardedFor,
+								Value:  testHeaderValueTest,
 							},
 							{
 								Action: "REMOVE",
-								Name:   "X-Forwarded-Proto",
+								Name:   testHeaderXForwardedProto,
 								Value:  "",
 							},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Protocol:  "HTTP",
-							Host:      "example.com",
+							Host:      testDomain,
 							Port:      utils.ToPTR(80),
-							Path:      "/newpath",
+							Path:      testNewPath,
 							KeepQuery: true,
 						},
 					},
@@ -533,8 +533,8 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -558,7 +558,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -576,7 +576,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -585,7 +585,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -593,7 +593,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -666,43 +666,43 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -714,8 +714,8 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -739,7 +739,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -748,16 +748,16 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -778,62 +778,62 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "X-Custom-Header",
-										Value:         []string{"value1", "value2"},
+										Key:           testHeaderXCustom,
+										Value:         []string{testHeaderValue1, "value2"},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
 									MatchCriteria: "BEGINS_WITH",
 									Value: []string{
-										"example.com",
+										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
 									MatchCriteria: "IS_IN",
 									StatusCodes: []string{
 										"200",
-										"301-303",
+										testRedirectCode,
 									},
 								},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
-								Host:      "example.com",
+								Host:      testDomain,
 								KeepQuery: true,
-								Path:      "/newpath",
+								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
 								Protocol:  "HTTP",
 							},
@@ -853,48 +853,48 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
 								Action: "ADD",
-								Name:   "X-Forwarded-For",
-								Value:  "test",
+								Name:   testHeaderXForwardedFor,
+								Value:  testHeaderValueTest,
 							},
 							{
 								Action: "REMOVE",
-								Name:   "X-Forwarded-Proto",
+								Name:   testHeaderXForwardedProto,
 							},
 						},
 					},
@@ -905,8 +905,8 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -930,7 +930,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -939,16 +939,16 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -969,67 +969,67 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "X-Custom-Header",
-										Value:         []string{"value1", "value2"},
+										Key:           testHeaderXCustom,
+										Value:         []string{testHeaderValue1, "value2"},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
 									MatchCriteria: "BEGINS_WITH",
 									Value: []string{
-										"example.com",
+										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
 									MatchCriteria: "IS_IN",
 									StatusCodes: []string{
 										"200",
-										"301-303",
+										testRedirectCode,
 									},
 								},
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
 									Action: "ADD",
-									Name:   "X-Forwarded-For",
-									Value:  "test",
+									Name:   testHeaderXForwardedFor,
+									Value:  testHeaderValueTest,
 								},
 								{
 									Action: "REMOVE",
-									Name:   "X-Forwarded-Proto",
+									Name:   testHeaderXForwardedProto,
 								},
 							},
 						},
@@ -1048,17 +1048,17 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:   "HTTP",
-							QueryMatch: []string{"key1=value1", "key2=value2"},
+							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -1070,8 +1070,8 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1095,7 +1095,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1104,16 +1104,16 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				getPoliciesHTTPResponse = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpResponseRule, error) {
 					return []*govcdtypes.AlbVsHttpResponseRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -1134,62 +1134,62 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "X-Custom-Header",
-										Value:         []string{"value1", "value2"},
+										Key:           testHeaderXCustom,
+										Value:         []string{testHeaderValue1, "value2"},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
 									MatchCriteria: "BEGINS_WITH",
 									Value: []string{
-										"example.com",
+										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
 									MatchCriteria: "IS_IN",
 									StatusCodes: []string{
 										"200",
-										"301-303",
+										testRedirectCode,
 									},
 								},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
-								Host:      "example.com",
+								Host:      testDomain,
 								KeepQuery: true,
-								Path:      "/newpath",
+								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
 								Protocol:  "HTTP",
 							},
@@ -1204,27 +1204,27 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name: "error-validation-model",
+			name: testErrorValidationModel,
 			policies: &PoliciesHTTPResponseModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: "session_id", Value: "abc123"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -1236,49 +1236,49 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 			err:         errors.New("Error:Field validation"),
 		},
 		{
-			name:        "error-refresh",
+			name:        testErrorRefresh,
 			expectedErr: true,
 			policies: &PoliciesHTTPResponseModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -1291,49 +1291,49 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:        "error-getVirtualService",
+			name:        testErrorGetVS,
 			expectedErr: true,
 			policies: &PoliciesHTTPResponseModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -1353,43 +1353,43 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{"example.com"}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "X-Custom-Header",
-									Values:   []string{"value1", "value2"},
+									Name:     testHeaderXCustom,
+									Values:   []string{testHeaderValue1, "value2"},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", "301-303"}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Host:      "example.com",
+							Host:      testDomain,
 							KeepQuery: true,
-							Path:      "/newpath",
+							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
 							Protocol:  "HTTP",
 						},
@@ -1457,8 +1457,8 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1482,7 +1482,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1496,7 +1496,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:             "error-delete",
+			name:             testErrorDelete,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1509,7 +1509,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 			err:         errors.New("error"),
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -1518,7 +1518,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -1526,7 +1526,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {

--- a/v1/edgeloadbalancer/policies_http_response_test.go
+++ b/v1/edgeloadbalancer/policies_http_response_test.go
@@ -49,7 +49,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 		err              error
 	}{
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -60,7 +60,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -77,7 +77,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -95,7 +95,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -103,22 +103,22 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -130,7 +130,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -138,7 +138,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -148,24 +148,24 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderXCustom,
-										Value:         []string{testHeaderValue1, "value2"},
+										Value:         []string{testHeaderValue1, testHeaderValue2},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Value: []string{
 										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									StatusCodes: []string{
 										"200",
 										testRedirectCode,
@@ -177,7 +177,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								KeepQuery: true,
 								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
-								Protocol:  "HTTP",
+								Protocol:  string(PoliciesHTTPProtocolHTTP),
 							},
 						},
 					}, nil
@@ -191,41 +191,41 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -245,7 +245,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -262,7 +262,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -279,7 +279,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
-								Protocol:           "HTTP",
+								Protocol:           string(PoliciesHTTPProtocolHTTP),
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
@@ -287,7 +287,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								KeepQuery: true,
 								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
-								Protocol:  "HTTP",
+								Protocol:  string(PoliciesHTTPProtocolHTTP),
 							},
 						},
 					}, nil
@@ -301,14 +301,14 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: string(PoliciesHTTPProtocolHTTP),
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -328,7 +328,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -345,7 +345,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -363,7 +363,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -371,22 +371,22 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -398,7 +398,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -406,7 +406,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -416,24 +416,24 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderXCustom,
-										Value:         []string{testHeaderValue1, "value2"},
+										Value:         []string{testHeaderValue1, testHeaderValue2},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Value: []string{
 										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									StatusCodes: []string{
 										"200",
 										testRedirectCode,
@@ -442,18 +442,18 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
-									Action: "ADD",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 									Name:   testHeaderXForwardedFor,
 									Value:  testHeaderValueTest,
 								},
 								{
-									Action: "REMOVE",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 									Name:   testHeaderXForwardedProto,
 									Value:  "",
 								},
 							},
 							RewriteLocationHeaderAction: &govcdtypes.AlbVsHttpRespRuleRewriteLocationHeaderAction{
-								Protocol:  "HTTP",
+								Protocol:  string(PoliciesHTTPProtocolHTTP),
 								Host:      testDomain,
 								Port:      utils.ToPTR(80),
 								Path:      testNewPath,
@@ -471,49 +471,49 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
 							QueryMatch:       []string{testQuery1, testQuery2},
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
-								Action: "ADD",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 								Name:   testHeaderXForwardedFor,
 								Value:  testHeaderValueTest,
 							},
 							{
-								Action: "REMOVE",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 								Name:   testHeaderXForwardedProto,
 								Value:  "",
 							},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 							Host:      testDomain,
 							Port:      utils.ToPTR(80),
 							Path:      testNewPath,
@@ -537,7 +537,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -554,7 +554,7 @@ func TestClient_GetPoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -661,7 +661,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 		err         error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			policies: &PoliciesHTTPResponseModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPResponseModelPolicy{
@@ -670,41 +670,41 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -718,7 +718,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -735,7 +735,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -753,7 +753,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -761,22 +761,22 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -788,7 +788,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -796,7 +796,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -806,24 +806,24 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderXCustom,
-										Value:         []string{testHeaderValue1, "value2"},
+										Value:         []string{testHeaderValue1, testHeaderValue2},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Value: []string{
 										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									StatusCodes: []string{
 										"200",
 										testRedirectCode,
@@ -835,7 +835,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								KeepQuery: true,
 								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
-								Protocol:  "HTTP",
+								Protocol:  string(PoliciesHTTPProtocolHTTP),
 							},
 						},
 					}, nil
@@ -857,43 +857,43 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						HeaderRewriteActions: PoliciesHTTPActionHeadersRewrite{
 							{
-								Action: "ADD",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 								Name:   testHeaderXForwardedFor,
 								Value:  testHeaderValueTest,
 							},
 							{
-								Action: "REMOVE",
+								Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 								Name:   testHeaderXForwardedProto,
 							},
 						},
@@ -909,7 +909,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -926,7 +926,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -944,7 +944,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -952,22 +952,22 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -979,7 +979,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -987,7 +987,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -997,24 +997,24 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderXCustom,
-										Value:         []string{testHeaderValue1, "value2"},
+										Value:         []string{testHeaderValue1, testHeaderValue2},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Value: []string{
 										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									StatusCodes: []string{
 										"200",
 										testRedirectCode,
@@ -1023,12 +1023,12 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 							},
 							HeaderActions: []*govcdtypes.AlbVsHttpRequestRuleHeaderActions{
 								{
-									Action: "ADD",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionADD),
 									Name:   testHeaderXForwardedFor,
 									Value:  testHeaderValueTest,
 								},
 								{
-									Action: "REMOVE",
+									Action: string(PoliciesHTTPActionHeaderRewriteActionREMOVE),
 									Name:   testHeaderXForwardedProto,
 								},
 							},
@@ -1052,7 +1052,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:   "HTTP",
+							Protocol:   string(PoliciesHTTPProtocolHTTP),
 							QueryMatch: []string{testQuery1, testQuery2},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
@@ -1060,7 +1060,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -1074,7 +1074,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1091,7 +1091,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1109,7 +1109,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpResponseRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -1117,22 +1117,22 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -1144,7 +1144,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								RequestHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -1152,7 +1152,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -1162,24 +1162,24 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								},
 								ResponseHeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderXCustom,
-										Value:         []string{testHeaderValue1, "value2"},
+										Value:         []string{testHeaderValue1, testHeaderValue2},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
 								LocationHeaderMatch: &govcdtypes.AlbVsHttpResponseLocationHeaderMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Value: []string{
 										testDomain,
 									},
 								},
 								StatusCodeMatch: &govcdtypes.AlbVsHttpRuleStatusCodeMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									StatusCodes: []string{
 										"200",
 										testRedirectCode,
@@ -1191,7 +1191,7 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 								KeepQuery: true,
 								Path:      testNewPath,
 								Port:      utils.ToPTR(80),
-								Protocol:  "HTTP",
+								Protocol:  string(PoliciesHTTPProtocolHTTP),
 							},
 						},
 					}, nil
@@ -1213,20 +1213,20 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Name: testCookieName, Value: testCookieValue},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -1246,41 +1246,41 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -1301,41 +1301,41 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -1357,41 +1357,41 @@ func TestClient_UpdatePoliciesHTTPResponse(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPResponseMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         string(PoliciesHTTPProtocolHTTP),
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
-							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
-							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: "BEGINS_WITH", Values: []string{testDomain}},
+							CookieMatch:      &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
+							LocationMatch:    &PoliciesHTTPLocationMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Values: []string{testDomain}},
 							RequestHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
 							ResponseHeaderMatch: PoliciesHTTPHeadersMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderXCustom,
-									Values:   []string{testHeaderValue1, "value2"},
+									Values:   []string{testHeaderValue1, testHeaderValue2},
 								},
 							},
-							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: "IS_IN", StatusCodes: []string{"200", testRedirectCode}},
+							StatusCodeMatch: &PoliciesHTTPStatusCodeMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), StatusCodes: []string{"200", testRedirectCode}},
 						},
 						LocationRewriteAction: &PoliciesHTTPActionLocationRewrite{
 							Host:      testDomain,
 							KeepQuery: true,
 							Path:      testNewPath,
 							Port:      utils.ToPTR(80),
-							Protocol:  "HTTP",
+							Protocol:  string(PoliciesHTTPProtocolHTTP),
 						},
 					},
 				},
@@ -1450,7 +1450,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 		err              error
 	}{
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1461,7 +1461,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1478,7 +1478,7 @@ func TestClient_DeletePoliciesHTTPResponse(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},

--- a/v1/edgeloadbalancer/policies_http_security_test.go
+++ b/v1/edgeloadbalancer/policies_http_security_test.go
@@ -58,8 +58,8 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -83,7 +83,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -92,16 +92,16 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -122,36 +122,36 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RedirectToHTTPSAction: &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{
@@ -165,29 +165,29 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -204,8 +204,8 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -229,7 +229,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -238,16 +238,16 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -268,42 +268,42 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
 								StatusCode:  404,
-								ContentType: "application/json",
-								Content:     "{\"key\":\"value\"}",
+								ContentType: testContentTypeJSON,
+								Content:     testJSONBody,
 							},
 						},
 					}, nil
@@ -313,34 +313,34 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						SendResponseAction: &PoliciesHTTPActionSendResponse{
 							StatusCode:  404,
-							ContentType: "application/json",
-							Content:     "{\"key\":\"value\"}",
+							ContentType: testContentTypeJSON,
+							Content:     testJSONBody,
 						},
 					},
 				},
@@ -356,8 +356,8 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -381,7 +381,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -390,16 +390,16 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -420,48 +420,48 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
 								Count:  100,
 								Period: 60,
 								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-									Host:       "example.com",
+									Host:       testDomain,
 									KeepQuery:  true,
 									Protocol:   "HTTPS",
 									Port:       utils.ToPTR(443),
 									StatusCode: 302,
-									Path:       "/newpath",
+									Path:       testNewPath,
 								},
 							},
 						},
@@ -472,40 +472,40 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
 							Period: 60,
 							RedirectAction: &PoliciesHTTPActionRedirect{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
 								Protocol:   "HTTPS",
 								Port:       utils.ToPTR(443),
 								StatusCode: 302,
-								Path:       "/newpath",
+								Path:       testNewPath,
 							},
 						},
 					},
@@ -522,8 +522,8 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -547,7 +547,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -556,16 +556,16 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -586,36 +586,36 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
@@ -623,8 +623,8 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								Period: 60,
 								LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
 									StatusCode:  404,
-									ContentType: "application/json",
-									Content:     "{\"key\":\"value\"}",
+									ContentType: testContentTypeJSON,
+									Content:     testJSONBody,
 								},
 							},
 						},
@@ -635,37 +635,37 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName",
+						Name:    testRuleName,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
 							Period: 60,
 							LocalResponseAction: &PoliciesHTTPActionSendResponse{
 								StatusCode:  404,
-								ContentType: "application/json",
-								Content:     "{\"key\":\"value\"}",
+								ContentType: testContentTypeJSON,
+								Content:     testJSONBody,
 							},
 						},
 					},
@@ -677,7 +677,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 		// ? ------------------------------------------------------------------------------
 		// ? ------------------------------ ERROR CASES -----------------------------------
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -686,7 +686,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -694,7 +694,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -770,29 +770,29 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -802,29 +802,29 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -835,8 +835,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -860,7 +860,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -869,16 +869,16 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName",
+							Name:    testRuleName,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
 									MatchCriteria: "IS_IN",
 									Addresses: []string{
-										"12.23.34.45",
-										"12.23.34.0/24",
-										"12.23.34.0-12.23.34.100",
+										testIPSingle,
+										testIPCIDR,
+										testIPRange,
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
@@ -899,36 +899,36 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 								QueryMatch: []string{
-									"key1=value1",
-									"key2=value2",
+									testQuery1,
+									testQuery2,
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "User-Agent",
+										Key:           testHeaderUserAgent,
 										Value: []string{
-											"Mozilla/5.0",
-											"curl/7.64.1",
+											testHeaderValueMozilla,
+											testHeaderValueCurl,
 										},
 									},
 									{
 										MatchCriteria: "IS_IN",
-										Key:           "Accept",
+										Key:           testHeaderAccept,
 										Value: []string{
-											"application/json",
-											"text/html",
+											testContentTypeJSON,
+											testContentTypeHTML,
 										},
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
 									MatchCriteria: "BEGINS_WITH",
-									Key:           "session_id",
-									Value:         "abc123",
+									Key:           testCookieName,
+									Value:         testCookieValue,
 								},
 							},
 							RedirectToHTTPSAction: &govcdtypes.AlbVsHttpSecurityRuleRedirectToHTTPSAction{
@@ -950,12 +950,12 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:  "HTTP",
-							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
 						},
 						// RedirectToHTTPSAction: utils.ToPTR(8443),
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
@@ -969,8 +969,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -994,7 +994,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1003,7 +1003,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName3",
+							Name:    testRuleName3,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
@@ -1011,8 +1011,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
 									MatchCriteria: "BEGINS_WITH",
 									MatchStrings: []string{
-										"/path1",
-										"/path2",
+										testPath1,
+										testPath2,
 									},
 								},
 							},
@@ -1032,12 +1032,12 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:  "HTTP",
-							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
 						},
 						// RedirectToHTTPSAction: utils.ToPTR(8443),
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
@@ -1057,7 +1057,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
@@ -1067,7 +1067,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Count:  100,
 							Period: 60,
 							RedirectAction: &PoliciesHTTPActionRedirect{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
 								Protocol:   "HTTPS",
 								Port:       utils.ToPTR(443),
@@ -1082,8 +1082,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1107,7 +1107,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1116,7 +1116,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName3",
+							Name:    testRuleName3,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
@@ -1126,7 +1126,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								Count:  100,
 								Period: 60,
 								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
-									Host:       "example.com",
+									Host:       testDomain,
 									KeepQuery:  true,
 									Protocol:   "HTTPS",
 									Port:       utils.ToPTR(443),
@@ -1144,7 +1144,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
@@ -1154,7 +1154,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Count:  100,
 							Period: 60,
 							RedirectAction: &PoliciesHTTPActionRedirect{
-								Host:       "example.com",
+								Host:       testDomain,
 								KeepQuery:  true,
 								Protocol:   "HTTPS",
 								Port:       utils.ToPTR(443),
@@ -1173,7 +1173,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
@@ -1184,8 +1184,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Period: 60,
 							LocalResponseAction: &PoliciesHTTPActionSendResponse{
 								StatusCode:  404,
-								ContentType: "application/json",
-								Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+								ContentType: testContentTypeJSON,
+								Content:     testBase64Body, // Note: JSON string : {"key":"value"}
 							},
 						},
 					},
@@ -1196,8 +1196,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1221,7 +1221,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1230,7 +1230,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				getPoliciesHTTPSecurity = func(_ fakeVirtualServiceClient) ([]*govcdtypes.AlbVsHttpSecurityRule, error) {
 					return []*govcdtypes.AlbVsHttpSecurityRule{
 						{
-							Name:    "ruleName3",
+							Name:    testRuleName3,
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
@@ -1241,8 +1241,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								Period: 60,
 								LocalResponseAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitLocalResponseAction{
 									StatusCode:  404,
-									ContentType: "application/json",
-									Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+									ContentType: testContentTypeJSON,
+									Content:     testBase64Body, // Note: JSON string : {"key":"value"}
 								},
 							},
 						},
@@ -1256,7 +1256,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
@@ -1267,8 +1267,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Period: 60,
 							LocalResponseAction: &PoliciesHTTPActionSendResponse{
 								StatusCode:  404,
-								ContentType: "application/json",
-								Content:     "eyJrZXkiOiJ2YWx1ZSJ9Cg==", // Note: JSON string : {"key":"value"}
+								ContentType: testContentTypeJSON,
+								Content:     testBase64Body, // Note: JSON string : {"key":"value"}
 							},
 						},
 					},
@@ -1280,35 +1280,35 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 		// ? ------------------------------------------------------------------------------
 		// ? ------------------------------ ERROR CASES -----------------------------------
 		{
-			name:        "error-refresh",
+			name:        testErrorRefresh,
 			expectedErr: true,
 			policies: &PoliciesHTTPSecurityModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1320,34 +1320,34 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name: "error-validation-model",
+			name: testErrorValidationModel,
 			policies: &PoliciesHTTPSecurityModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName3",
+						Name:    testRuleName3,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1358,35 +1358,35 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 			err:         errors.New("Error:Field validation"),
 		},
 		{
-			name:        "error-getVirtualService",
+			name:        testErrorGetVS,
 			expectedErr: true,
 			policies: &PoliciesHTTPSecurityModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1405,29 +1405,29 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
 					{
-						Name:    "ruleName2",
+						Name:    testRuleName2,
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
 							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{"12.23.34.45", "12.23.34.0/24", "12.23.34.0-12.23.34.100"}},
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
 							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
 							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{"/path1", "/path2"}},
-							QueryMatch:       []string{"key1=value1", "key2=value2"},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
 									Criteria: "IS_IN",
-									Name:     "User-Agent",
-									Values:   []string{"Mozilla/5.0", "curl/7.64.1"},
+									Name:     testHeaderUserAgent,
+									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
 									Criteria: "IS_IN",
-									Name:     "Accept",
-									Values:   []string{"application/json", "text/html"},
+									Name:     testHeaderAccept,
+									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: "session_id", Value: "abc123"},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1496,8 +1496,8 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1521,7 +1521,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1550,7 +1550,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 			err:         errors.New("error"),
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -1559,7 +1559,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 			err: errors.New("error"),
 		},
 		{
-			name:             "error-virtualserviceValidation",
+			name:             testErrorVSValidation,
 			expectedErr:      true,
 			virtualServiceID: "",
 			mockFunc: func() {
@@ -1567,7 +1567,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 			err: errors.New("virtualServiceID is empty. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-getVirtualService",
+			name:             testErrorGetVS,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {

--- a/v1/edgeloadbalancer/policies_http_security_test.go
+++ b/v1/edgeloadbalancer/policies_http_security_test.go
@@ -62,7 +62,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -79,7 +79,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -97,7 +97,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -105,22 +105,22 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -132,7 +132,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -140,7 +140,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -149,7 +149,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -169,25 +169,25 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -208,7 +208,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -225,7 +225,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -243,7 +243,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -251,22 +251,22 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -278,7 +278,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -286,7 +286,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -295,7 +295,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -317,25 +317,25 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						SendResponseAction: &PoliciesHTTPActionSendResponse{
 							StatusCode:  404,
@@ -360,7 +360,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -377,7 +377,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -395,7 +395,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -403,22 +403,22 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -430,7 +430,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -438,7 +438,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -447,7 +447,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -458,7 +458,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
 									Host:       testDomain,
 									KeepQuery:  true,
-									Protocol:   "HTTPS",
+									Protocol:   string(PoliciesHTTPProtocolHTTPS),
 									Port:       utils.ToPTR(443),
 									StatusCode: 302,
 									Path:       testNewPath,
@@ -476,25 +476,25 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -502,7 +502,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 							RedirectAction: &PoliciesHTTPActionRedirect{
 								Host:       testDomain,
 								KeepQuery:  true,
-								Protocol:   "HTTPS",
+								Protocol:   string(PoliciesHTTPProtocolHTTPS),
 								Port:       utils.ToPTR(443),
 								StatusCode: 302,
 								Path:       testNewPath,
@@ -526,7 +526,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -543,7 +543,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -561,7 +561,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -569,22 +569,22 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -596,7 +596,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -604,7 +604,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -613,7 +613,7 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -639,25 +639,25 @@ func TestClient_GetPoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -765,7 +765,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 		// ? ------------------------------------------------------------------------------
 		// ? ------------------------------ SUCCESS CASES ---------------------------------
 		{
-			name: "success",
+			name: testSuccess,
 			policies: &PoliciesHTTPSecurityModel{
 				VirtualServiceID: virtualServiceID,
 				Policies: []*PoliciesHTTPSecurityModelPolicy{
@@ -774,25 +774,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -806,25 +806,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -839,7 +839,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -856,7 +856,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -874,7 +874,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
 								ClientIPMatch: &govcdtypes.AlbVsHttpRequestRuleClientIPMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Addresses: []string{
 										testIPSingle,
 										testIPCIDR,
@@ -882,22 +882,22 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								ServicePortMatch: &govcdtypes.AlbVsHttpRequestRuleServicePortMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Ports: []int{
 										80,
 										443,
 									},
 								},
 								MethodMatch: &govcdtypes.AlbVsHttpRequestRuleMethodMatch{
-									MatchCriteria: "IS_IN",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Methods: []string{
-										"GET",
-										"POST",
+										string(PoliciesHTTPMethodGET),
+										string(PoliciesHTTPMethodPOST),
 									},
 								},
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -909,7 +909,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								},
 								HeaderMatch: []govcdtypes.AlbVsHttpRequestRuleHeaderMatch{
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderUserAgent,
 										Value: []string{
 											testHeaderValueMozilla,
@@ -917,7 +917,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 										},
 									},
 									{
-										MatchCriteria: "IS_IN",
+										MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 										Key:           testHeaderAccept,
 										Value: []string{
 											testContentTypeJSON,
@@ -926,7 +926,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 									},
 								},
 								CookieMatch: &govcdtypes.AlbVsHttpRequestRuleCookieMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									Key:           testCookieName,
 									Value:         testCookieValue,
 								},
@@ -954,8 +954,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:  "HTTP",
-							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:  PoliciesHTTPProtocolHTTP,
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 						},
 						// RedirectToHTTPSAction: utils.ToPTR(8443),
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
@@ -973,7 +973,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -990,7 +990,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1007,9 +1007,9 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 								PathMatch: &govcdtypes.AlbVsHttpRequestRulePathMatch{
-									MatchCriteria: "BEGINS_WITH",
+									MatchCriteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH),
 									MatchStrings: []string{
 										testPath1,
 										testPath2,
@@ -1036,8 +1036,8 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:  "HTTP",
-							PathMatch: &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:  PoliciesHTTPProtocolHTTP,
+							PathMatch: &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 						},
 						// RedirectToHTTPSAction: utils.ToPTR(8443),
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
@@ -1061,7 +1061,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: PoliciesHTTPProtocolHTTP,
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -1069,7 +1069,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							RedirectAction: &PoliciesHTTPActionRedirect{
 								Host:       testDomain,
 								KeepQuery:  true,
-								Protocol:   "HTTPS",
+								Protocol:   string(PoliciesHTTPProtocolHTTPS),
 								Port:       utils.ToPTR(443),
 								StatusCode: 302,
 							},
@@ -1086,7 +1086,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1103,7 +1103,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1120,7 +1120,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 							},
 							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
 								Count:  100,
@@ -1128,7 +1128,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								RedirectAction: &govcdtypes.AlbVsHttpRequestRuleRedirectAction{
 									Host:       testDomain,
 									KeepQuery:  true,
-									Protocol:   "HTTPS",
+									Protocol:   string(PoliciesHTTPProtocolHTTPS),
 									Port:       utils.ToPTR(443),
 									StatusCode: 302,
 								},
@@ -1148,7 +1148,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: PoliciesHTTPProtocolHTTP,
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -1156,7 +1156,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							RedirectAction: &PoliciesHTTPActionRedirect{
 								Host:       testDomain,
 								KeepQuery:  true,
-								Protocol:   "HTTPS",
+								Protocol:   string(PoliciesHTTPProtocolHTTPS),
 								Port:       utils.ToPTR(443),
 								StatusCode: 302,
 							},
@@ -1177,7 +1177,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: PoliciesHTTPProtocolHTTP,
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -1200,7 +1200,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1217,7 +1217,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1234,7 +1234,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 							Active:  true,
 							Logging: true,
 							MatchCriteria: govcdtypes.AlbVsHttpRequestAndSecurityRuleMatchCriteria{
-								Protocol: "HTTP",
+								Protocol: string(PoliciesHTTPProtocolHTTP),
 							},
 							RateLimitAction: &govcdtypes.AlbVsHttpSecurityRuleRateLimitAction{
 								Count:  100,
@@ -1260,7 +1260,7 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol: "HTTP",
+							Protocol: PoliciesHTTPProtocolHTTP,
 						},
 						RateLimitAction: &PoliciesHTTPActionRateLimit{
 							Count:  100,
@@ -1290,25 +1290,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1329,25 +1329,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "IS_IN", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "IS_IN", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1368,25 +1368,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1409,25 +1409,25 @@ func TestClient_UpdatePoliciesHTTPSecurity(t *testing.T) {
 						Active:  true,
 						Logging: true,
 						MatchCriteria: PoliciesHTTPSecurityMatchCriteria{
-							Protocol:         "HTTP",
-							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: "IS_IN", Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
-							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: "IS_IN", Ports: []int{80, 443}},
-							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: "IS_IN", Methods: []string{"GET", "POST"}},
-							PathMatch:        &PoliciesHTTPPathMatch{Criteria: "BEGINS_WITH", MatchStrings: []string{testPath1, testPath2}},
+							Protocol:         PoliciesHTTPProtocolHTTP,
+							ClientIPMatch:    &PoliciesHTTPClientIPMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Addresses: []string{testIPSingle, testIPCIDR, testIPRange}},
+							ServicePortMatch: &PoliciesHTTPServicePortMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Ports: []int{80, 443}},
+							MethodMatch:      &PoliciesHTTPMethodMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN), Methods: []string{string(PoliciesHTTPMethodGET), string(PoliciesHTTPMethodPOST)}},
+							PathMatch:        &PoliciesHTTPPathMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), MatchStrings: []string{testPath1, testPath2}},
 							QueryMatch:       []string{testQuery1, testQuery2},
 							HeaderMatch: []PoliciesHTTPHeaderMatch{
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderUserAgent,
 									Values:   []string{testHeaderValueMozilla, testHeaderValueCurl},
 								},
 								{
-									Criteria: "IS_IN",
+									Criteria: string(PoliciesHTTPMatchCriteriaCriteriaISIN),
 									Name:     testHeaderAccept,
 									Values:   []string{testContentTypeJSON, testContentTypeHTML},
 								},
 							},
-							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: "BEGINS_WITH", Name: testCookieName, Value: testCookieValue},
+							CookieMatch: &PoliciesHTTPCookieMatch{Criteria: string(PoliciesHTTPMatchCriteriaCriteriaBEGINSWITH), Name: testCookieName, Value: testCookieValue},
 						},
 						RedirectToHTTPSAction: utils.ToPTR(8443),
 					},
@@ -1489,7 +1489,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 		// ? ------------------------------------------------------------------------------
 		// ? ------------------------------ SUCCESS CASES ---------------------------------
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1500,7 +1500,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(PoliciesHTTPProtocolHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1517,7 +1517,7 @@ func TestClient_DeletePoliciesHTTPSecurity(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},

--- a/v1/edgeloadbalancer/pool_test.go
+++ b/v1/edgeloadbalancer/pool_test.go
@@ -65,18 +65,18 @@ func TestClient_GetPool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -96,7 +96,7 @@ func TestClient_GetPool(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -171,18 +171,18 @@ func TestClient_GetPool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -365,7 +365,7 @@ func TestClient_ListPools(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			edgeGatewayID: urnEdgeGateway,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(3)
@@ -394,18 +394,18 @@ func TestClient_ListPools(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -425,7 +425,7 @@ func TestClient_ListPools(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -442,18 +442,18 @@ func TestClient_ListPools(t *testing.T) {
 						Description:              testPoolName2Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -473,7 +473,7 @@ func TestClient_ListPools(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -650,18 +650,18 @@ func TestClient_ListPools(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -681,7 +681,7 @@ func TestClient_ListPools(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -749,13 +749,13 @@ func TestClient_CreatePool(t *testing.T) {
 		err           error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			pool: PoolModelRequest{
 				Name:                     testPoolName1,
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -799,18 +799,18 @@ func TestClient_CreatePool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -830,7 +830,7 @@ func TestClient_CreatePool(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -847,7 +847,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -897,7 +897,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -927,18 +927,18 @@ func TestClient_CreatePool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members:                nil,
@@ -948,7 +948,7 @@ func TestClient_CreatePool(t *testing.T) {
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
 							Name:  testPoolPersistence,
-							Type:  "CLIENT_IP",
+							Type:  string(PoolPersistenceProfileTypeClientIP),
 							Value: "",
 						},
 						MemberCount:        1,
@@ -965,7 +965,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1072,7 +1072,7 @@ func TestClient_CreatePool(t *testing.T) {
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				DefaultPort:              utils.ToPTR(80),
-				Algorithm:                "LEAST_CONNECTIONS", // LEAST CONNECTIONS instead of LEAST_CONNECTIONS
+				Algorithm:                PoolAlgorithmLeastConnections, // LEAST CONNECTIONS instead of LEAST_CONNECTIONS
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
@@ -1106,7 +1106,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1156,7 +1156,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1243,14 +1243,14 @@ func TestClient_UpdatePool(t *testing.T) {
 		err           error
 	}{
 		{
-			name:   "success",
+			name:   testSuccess,
 			poolID: urnPool,
 			pool: PoolModelRequest{
 				Name:                     testPoolPoule2,
 				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1294,18 +1294,18 @@ func TestClient_UpdatePool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -1340,18 +1340,18 @@ func TestClient_UpdatePool(t *testing.T) {
 							Description:              testPoolPouleDesc,
 							GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 							Enabled:                  utils.ToPTR(true),
-							Algorithm:                "LEAST_CONNECTIONS",
+							Algorithm:                string(PoolAlgorithmLeastConnections),
 							DefaultPort:              utils.ToPTR(80),
 							GracefulTimeoutPeriod:    utils.ToPTR(10),
 							PassiveMonitoringEnabled: utils.ToPTR(true),
 							HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 								{
 									Name: testPoolMonitorHTTP,
-									Type: "HTTP",
+									Type: string(PoolHealthMonitorTypeHTTP),
 								},
 								{
 									Name: testPoolMonitorTCP,
-									Type: "TCP",
+									Type: string(PoolHealthMonitorTypeTCP),
 								},
 							},
 							Members: []govcdtypes.NsxtAlbPoolMember{
@@ -1385,7 +1385,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1466,7 +1466,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1515,7 +1515,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1565,7 +1565,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
-				Algorithm:                "LEAST_CONNECTIONS",
+				Algorithm:                PoolAlgorithmLeastConnections,
 				DefaultPort:              utils.ToPTR(80),
 				GracefulTimeoutPeriod:    utils.ToPTR(10),
 				PassiveMonitoringEnabled: utils.ToPTR(true),
@@ -1609,18 +1609,18 @@ func TestClient_UpdatePool(t *testing.T) {
 						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
-						Algorithm:                "LEAST_CONNECTIONS",
+						Algorithm:                string(PoolAlgorithmLeastConnections),
 						DefaultPort:              utils.ToPTR(80),
 						GracefulTimeoutPeriod:    utils.ToPTR(10),
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
 								Name: testPoolMonitorHTTP,
-								Type: "HTTP",
+								Type: string(PoolHealthMonitorTypeHTTP),
 							},
 							{
 								Name: testPoolMonitorTCP,
-								Type: "TCP",
+								Type: string(PoolHealthMonitorTypeTCP),
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
@@ -1696,7 +1696,7 @@ func TestClient_DeletePool(t *testing.T) {
 		err         error
 	}{
 		{
-			name:   "success",
+			name:   testSuccess,
 			poolID: urnPool,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)

--- a/v1/edgeloadbalancer/pool_test.go
+++ b/v1/edgeloadbalancer/pool_test.go
@@ -54,15 +54,15 @@ func TestClient_GetPool(t *testing.T) {
 			name:          "success-http-by-name",
 			edgeGatewayID: urnEdgeGateway,
 			poolID:        poolID,
-			poolName:      "pool1",
-			byNameOrID:    "name",
+			poolName:      testPoolName1,
+			byNameOrID:    testName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
-				clientCAV.EXPECT().GetAlbPoolByName(urnEdgeGateway, "pool1").Return(&govcd.NsxtAlbPool{
+				clientCAV.EXPECT().GetAlbPoolByName(urnEdgeGateway, testPoolName1).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       poolID,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -71,18 +71,18 @@ func TestClient_GetPool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -95,13 +95,13 @@ func TestClient_GetPool(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -109,8 +109,8 @@ func TestClient_GetPool(t *testing.T) {
 			},
 			expectedValue: &PoolModel{
 				ID:                       poolID,
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                PoolAlgorithmLeastConnections,
@@ -119,18 +119,18 @@ func TestClient_GetPool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -143,13 +143,13 @@ func TestClient_GetPool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false),
 				DomainNames:            nil,
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
 				MemberCount:        1,
 				UpMemberCount:      1,
-				HealthMessage:      "All members are up",
+				HealthMessage:      testPoolMembersStatus,
 				VirtualServiceRefs: nil,
 				SSLEnabled:         utils.ToPTR(false),
 			},
@@ -160,15 +160,15 @@ func TestClient_GetPool(t *testing.T) {
 			name:          "success-http-by-id",
 			edgeGatewayID: urnEdgeGateway,
 			poolID:        poolID,
-			poolName:      "pool1",
+			poolName:      testPoolName1,
 			byNameOrID:    "id",
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetAlbPoolById(poolID).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       poolID,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -177,18 +177,18 @@ func TestClient_GetPool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -203,7 +203,7 @@ func TestClient_GetPool(t *testing.T) {
 						PersistenceProfile:     nil,
 						MemberCount:            1,
 						UpMemberCount:          1,
-						HealthMessage:          "All members are up",
+						HealthMessage:          testPoolMembersStatus,
 						VirtualServiceRefs:     nil,
 						SslEnabled:             utils.ToPTR(false),
 					},
@@ -211,8 +211,8 @@ func TestClient_GetPool(t *testing.T) {
 			},
 			expectedValue: &PoolModel{
 				ID:                       poolID,
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                PoolAlgorithmLeastConnections,
@@ -221,18 +221,18 @@ func TestClient_GetPool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -247,7 +247,7 @@ func TestClient_GetPool(t *testing.T) {
 				PersistenceProfile:     nil,
 				MemberCount:            1,
 				UpMemberCount:          1,
-				HealthMessage:          "All members are up",
+				HealthMessage:          testPoolMembersStatus,
 				VirtualServiceRefs:     nil,
 				SSLEnabled:             utils.ToPTR(false),
 			},
@@ -255,7 +255,7 @@ func TestClient_GetPool(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: urnEdgeGateway,
 			poolID:        poolID,
 			byNameOrID:    "id",
@@ -267,10 +267,10 @@ func TestClient_GetPool(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:          "error-get",
+			name:          testErrorGetShort,
 			edgeGatewayID: urnEdgeGateway,
 			poolID:        poolID,
-			poolName:      "pool1",
+			poolName:      testPoolName1,
 			byNameOrID:    "id",
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -281,10 +281,10 @@ func TestClient_GetPool(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:          "param-edgeGatewayID-empty",
+			name:          testPoolParamEdgeEmpty,
 			edgeGatewayID: "",
 			poolID:        poolID,
-			poolName:      "pool1",
+			poolName:      testPoolName1,
 			byNameOrID:    "id",
 			mockFunc: func() {
 			},
@@ -293,10 +293,10 @@ func TestClient_GetPool(t *testing.T) {
 			err:           errors.New("edgeGatewayID is empty. Please provide a valid edgeGatewayID"),
 		},
 		{
-			name:          "param-edgeGatewayID-invalid-id",
+			name:          testPoolParamEdgeInvalid,
 			edgeGatewayID: "1234",
 			poolID:        "1234",
-			poolName:      "pool1",
+			poolName:      testPoolName1,
 			byNameOrID:    "id",
 			mockFunc: func() {
 			},
@@ -308,7 +308,7 @@ func TestClient_GetPool(t *testing.T) {
 			name:          "param-poolNameOrID-empty",
 			edgeGatewayID: urnEdgeGateway,
 			poolID:        "",
-			byNameOrID:    "name",
+			byNameOrID:    testName,
 			mockFunc: func() {
 			},
 			expectedValue: &PoolModel{},
@@ -373,16 +373,16 @@ func TestClient_ListPools(t *testing.T) {
 					{
 						NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 							ID:          poolID,
-							Name:        "pool1",
-							Description: "pool1 description",
+							Name:        testPoolName1,
+							Description: testPoolName1Desc,
 							GatewayRef:  govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						},
 					},
 					{
 						NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 							ID:          poolID2,
-							Name:        "pool2",
-							Description: "pool2 description",
+							Name:        testPoolName2,
+							Description: testPoolName2Desc,
 							GatewayRef:  govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						},
 					},
@@ -390,8 +390,8 @@ func TestClient_ListPools(t *testing.T) {
 				clientCAV.EXPECT().GetAlbPoolById(poolID).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       poolID,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -400,18 +400,18 @@ func TestClient_ListPools(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -424,13 +424,13 @@ func TestClient_ListPools(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -438,8 +438,8 @@ func TestClient_ListPools(t *testing.T) {
 				clientCAV.EXPECT().GetAlbPoolById(poolID2).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       poolID2,
-						Name:                     "pool2",
-						Description:              "pool2 description",
+						Name:                     testPoolName2,
+						Description:              testPoolName2Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -448,11 +448,11 @@ func TestClient_ListPools(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
@@ -472,13 +472,13 @@ func TestClient_ListPools(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -487,8 +487,8 @@ func TestClient_ListPools(t *testing.T) {
 			expectedValue: []*PoolModel{
 				{
 					ID:                       poolID,
-					Name:                     "pool1",
-					Description:              "pool1 description",
+					Name:                     testPoolName1,
+					Description:              testPoolName1Desc,
 					GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 					Enabled:                  utils.ToPTR(true),
 					Algorithm:                PoolAlgorithmLeastConnections,
@@ -497,18 +497,18 @@ func TestClient_ListPools(t *testing.T) {
 					PassiveMonitoringEnabled: utils.ToPTR(true),
 					HealthMonitors: []PoolModelHealthMonitor{
 						{
-							Name: "monitor HTTP",
+							Name: testPoolMonitorHTTP,
 							Type: PoolHealthMonitorTypeHTTP,
 						},
 						{
-							Name: "monitor TCP",
+							Name: testPoolMonitorTCP,
 							Type: PoolHealthMonitorTypeTCP,
 						},
 					},
 					Members: []PoolModelMember{
 						{
 							Enabled:               true,
-							IPAddress:             "192.168.0.1",
+							IPAddress:             testIPAddress,
 							Port:                  80,
 							Ratio:                 utils.ToPTR(1),
 							MarkedDownBy:          nil,
@@ -521,20 +521,20 @@ func TestClient_ListPools(t *testing.T) {
 					CommonNameCheckEnabled: utils.ToPTR(false),
 					DomainNames:            nil,
 					PersistenceProfile: &PoolModelPersistenceProfile{
-						Name:  "persistence profile",
+						Name:  testPoolPersistence,
 						Type:  PoolPersistenceProfileTypeClientIP,
 						Value: "",
 					},
 					MemberCount:        1,
 					UpMemberCount:      1,
-					HealthMessage:      "All members are up",
+					HealthMessage:      testPoolMembersStatus,
 					VirtualServiceRefs: nil,
 					SSLEnabled:         utils.ToPTR(false),
 				},
 				{
 					ID:                       poolID2,
-					Name:                     "pool2",
-					Description:              "pool2 description",
+					Name:                     testPoolName2,
+					Description:              testPoolName2Desc,
 					GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 					Enabled:                  utils.ToPTR(true),
 					Algorithm:                PoolAlgorithmLeastConnections,
@@ -543,11 +543,11 @@ func TestClient_ListPools(t *testing.T) {
 					PassiveMonitoringEnabled: utils.ToPTR(true),
 					HealthMonitors: []PoolModelHealthMonitor{
 						{
-							Name: "monitor HTTP",
+							Name: testPoolMonitorHTTP,
 							Type: PoolHealthMonitorTypeHTTP,
 						},
 						{
-							Name: "monitor TCP",
+							Name: testPoolMonitorTCP,
 							Type: PoolHealthMonitorTypeTCP,
 						},
 					},
@@ -567,13 +567,13 @@ func TestClient_ListPools(t *testing.T) {
 					CommonNameCheckEnabled: utils.ToPTR(false),
 					DomainNames:            nil,
 					PersistenceProfile: &PoolModelPersistenceProfile{
-						Name:  "persistence profile",
+						Name:  testPoolPersistence,
 						Type:  PoolPersistenceProfileTypeClientIP,
 						Value: "",
 					},
 					MemberCount:        1,
 					UpMemberCount:      1,
-					HealthMessage:      "All members are up",
+					HealthMessage:      testPoolMembersStatus,
 					VirtualServiceRefs: nil,
 					SSLEnabled:         utils.ToPTR(false),
 				},
@@ -582,7 +582,7 @@ func TestClient_ListPools(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:          "param-edgeGatewayID-empty",
+			name:          testPoolParamEdgeEmpty,
 			edgeGatewayID: "",
 			mockFunc: func() {
 			},
@@ -591,7 +591,7 @@ func TestClient_ListPools(t *testing.T) {
 			err:           errors.New("edgeGatewayID is empty. Please provide a valid edgeGatewayID"),
 		},
 		{
-			name:          "param-edgeGatewayID-invalid-id",
+			name:          testPoolParamEdgeInvalid,
 			edgeGatewayID: "1234",
 			mockFunc: func() {
 			},
@@ -600,7 +600,7 @@ func TestClient_ListPools(t *testing.T) {
 			err:           errors.New("edgeGatewayID has invalid format. Please provide a valid edgeGatewayID"),
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: urnEdgeGateway,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
@@ -629,16 +629,16 @@ func TestClient_ListPools(t *testing.T) {
 					{
 						NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 							ID:          poolID,
-							Name:        "pool1",
-							Description: "pool1 description",
+							Name:        testPoolName1,
+							Description: testPoolName1Desc,
 							GatewayRef:  govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						},
 					},
 					{
 						NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 							ID:          poolID2,
-							Name:        "pool2",
-							Description: "pool2 description",
+							Name:        testPoolName2,
+							Description: testPoolName2Desc,
 							GatewayRef:  govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						},
 					},
@@ -646,8 +646,8 @@ func TestClient_ListPools(t *testing.T) {
 				clientCAV.EXPECT().GetAlbPoolById(poolID).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       poolID,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -656,18 +656,18 @@ func TestClient_ListPools(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -680,13 +680,13 @@ func TestClient_ListPools(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -751,8 +751,8 @@ func TestClient_CreatePool(t *testing.T) {
 		{
 			name: "success",
 			pool: PoolModelRequest{
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -761,18 +761,18 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -785,7 +785,7 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -795,8 +795,8 @@ func TestClient_CreatePool(t *testing.T) {
 				clientCAV.EXPECT().CreateNsxtAlbPool(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbPool{})).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       urnPool,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -805,18 +805,18 @@ func TestClient_CreatePool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -829,13 +829,13 @@ func TestClient_CreatePool(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -843,8 +843,8 @@ func TestClient_CreatePool(t *testing.T) {
 			},
 			expectedValue: &PoolModel{
 				ID:                       urnPool,
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -853,18 +853,18 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -877,13 +877,13 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
 				MemberCount:        1,
 				UpMemberCount:      1,
-				HealthMessage:      "All members are up",
+				HealthMessage:      testPoolMembersStatus,
 				VirtualServiceRefs: nil,
 				SSLEnabled:         utils.ToPTR(false),
 			},
@@ -893,8 +893,8 @@ func TestClient_CreatePool(t *testing.T) {
 		{
 			name: "success-member-ref-and-no-persistence-profile",
 			pool: PoolModelRequest{
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -903,11 +903,11 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
@@ -923,8 +923,8 @@ func TestClient_CreatePool(t *testing.T) {
 				clientCAV.EXPECT().CreateNsxtAlbPool(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbPool{})).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       urnPool,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -933,11 +933,11 @@ func TestClient_CreatePool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
@@ -947,13 +947,13 @@ func TestClient_CreatePool(t *testing.T) {
 						CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 						DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 						PersistenceProfile: &govcdtypes.NsxtAlbPoolPersistenceProfile{
-							Name:  "persistence profile",
+							Name:  testPoolPersistence,
 							Type:  "CLIENT_IP",
 							Value: "",
 						},
 						MemberCount:        1,
 						UpMemberCount:      1,
-						HealthMessage:      "All members are up",
+						HealthMessage:      testPoolMembersStatus,
 						VirtualServiceRefs: nil,
 						SslEnabled:         utils.ToPTR(false),
 					},
@@ -961,8 +961,8 @@ func TestClient_CreatePool(t *testing.T) {
 			},
 			expectedValue: &PoolModel{
 				ID:                       urnPool,
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -971,11 +971,11 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
@@ -985,13 +985,13 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
 				MemberCount:        1,
 				UpMemberCount:      1,
-				HealthMessage:      "All members are up",
+				HealthMessage:      testPoolMembersStatus,
 				VirtualServiceRefs: nil,
 				SSLEnabled:         utils.ToPTR(false),
 			},
@@ -1005,8 +1005,8 @@ func TestClient_CreatePool(t *testing.T) {
 				Algorithm: "LEAST CONNECTIONS", // LEAST CONNECTIONS instead of LEAST_CONNECTIONS
 
 				// Valid fields
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				DefaultPort:              utils.ToPTR(80),
@@ -1014,18 +1014,18 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1038,7 +1038,7 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1056,7 +1056,7 @@ func TestClient_CreatePool(t *testing.T) {
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1067,8 +1067,8 @@ func TestClient_CreatePool(t *testing.T) {
 				MemberGroupRef: &govcdtypes.OpenApiReference{ID: urnIPSet},
 
 				// Valid fields
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				DefaultPort:              utils.ToPTR(80),
@@ -1077,11 +1077,11 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
@@ -1089,7 +1089,7 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1102,8 +1102,8 @@ func TestClient_CreatePool(t *testing.T) {
 		{
 			name: "error-create-pool",
 			pool: PoolModelRequest{
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1112,18 +1112,18 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1136,7 +1136,7 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1150,10 +1150,10 @@ func TestClient_CreatePool(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name: "refresh-error",
+			name: testErrorRefreshShort,
 			pool: PoolModelRequest{
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1162,18 +1162,18 @@ func TestClient_CreatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1186,7 +1186,7 @@ func TestClient_CreatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1246,8 +1246,8 @@ func TestClient_UpdatePool(t *testing.T) {
 			name:   "success",
 			poolID: urnPool,
 			pool: PoolModelRequest{
-				Name:                     "poule 2",
-				Description:              "poule description",
+				Name:                     testPoolPoule2,
+				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1256,18 +1256,18 @@ func TestClient_UpdatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1280,7 +1280,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1290,8 +1290,8 @@ func TestClient_UpdatePool(t *testing.T) {
 				clientCAV.EXPECT().GetAlbPoolById(urnPool).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       urnPool,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -1300,18 +1300,18 @@ func TestClient_UpdatePool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -1326,7 +1326,7 @@ func TestClient_UpdatePool(t *testing.T) {
 						PersistenceProfile:     nil,
 						MemberCount:            1,
 						UpMemberCount:          1,
-						HealthMessage:          "All members are up",
+						HealthMessage:          testPoolMembersStatus,
 						VirtualServiceRefs:     nil,
 						SslEnabled:             utils.ToPTR(false),
 					},
@@ -1336,8 +1336,8 @@ func TestClient_UpdatePool(t *testing.T) {
 					return &govcd.NsxtAlbPool{
 						NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 							ID:                       urnPool,
-							Name:                     "poule 2",
-							Description:              "poule description",
+							Name:                     testPoolPoule2,
+							Description:              testPoolPouleDesc,
 							GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 							Enabled:                  utils.ToPTR(true),
 							Algorithm:                "LEAST_CONNECTIONS",
@@ -1346,18 +1346,18 @@ func TestClient_UpdatePool(t *testing.T) {
 							PassiveMonitoringEnabled: utils.ToPTR(true),
 							HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 								{
-									Name: "monitor HTTP",
+									Name: testPoolMonitorHTTP,
 									Type: "HTTP",
 								},
 								{
-									Name: "monitor TCP",
+									Name: testPoolMonitorTCP,
 									Type: "TCP",
 								},
 							},
 							Members: []govcdtypes.NsxtAlbPoolMember{
 								{
 									Enabled:               true,
-									IpAddress:             "192.168.0.1",
+									IpAddress:             testIPAddress,
 									Port:                  80,
 									Ratio:                 utils.ToPTR(1),
 									MarkedDownBy:          nil,
@@ -1372,7 +1372,7 @@ func TestClient_UpdatePool(t *testing.T) {
 							PersistenceProfile:     nil,
 							MemberCount:            1,
 							UpMemberCount:          1,
-							HealthMessage:          "All members are up",
+							HealthMessage:          testPoolMembersStatus,
 							VirtualServiceRefs:     nil,
 							SslEnabled:             utils.ToPTR(false),
 						},
@@ -1381,8 +1381,8 @@ func TestClient_UpdatePool(t *testing.T) {
 			},
 			expectedValue: &PoolModel{
 				ID:                       urnPool,
-				Name:                     "poule 2",
-				Description:              "poule description",
+				Name:                     testPoolPoule2,
+				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1391,18 +1391,18 @@ func TestClient_UpdatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1415,13 +1415,13 @@ func TestClient_UpdatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
 				MemberCount:        1,
 				UpMemberCount:      1,
-				HealthMessage:      "All members are up",
+				HealthMessage:      testPoolMembersStatus,
 				VirtualServiceRefs: nil,
 				SSLEnabled:         utils.ToPTR(false),
 			},
@@ -1449,7 +1449,7 @@ func TestClient_UpdatePool(t *testing.T) {
 			err:           errors.New("poolID has invalid format. Please provide a valid poolID"),
 		},
 		{
-			name:   "error-validation",
+			name:   testErrorValidation,
 			poolID: urnPool,
 			pool:   PoolModelRequest{},
 			mockFunc: func() {
@@ -1459,11 +1459,11 @@ func TestClient_UpdatePool(t *testing.T) {
 			err:           errors.New("Error:Field validation for 'Name' failed on the 'required'"),
 		},
 		{
-			name:   "refresh-error",
+			name:   testErrorRefreshShort,
 			poolID: urnPool,
 			pool: PoolModelRequest{
-				Name:                     "pool1",
-				Description:              "pool1 description",
+				Name:                     testPoolName1,
+				Description:              testPoolName1Desc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1472,18 +1472,18 @@ func TestClient_UpdatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1496,7 +1496,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1511,8 +1511,8 @@ func TestClient_UpdatePool(t *testing.T) {
 			name:   "get-pool-error",
 			poolID: urnPool,
 			pool: PoolModelRequest{
-				Name:                     "poule 2",
-				Description:              "poule description",
+				Name:                     testPoolPoule2,
+				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1521,18 +1521,18 @@ func TestClient_UpdatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1545,7 +1545,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1561,8 +1561,8 @@ func TestClient_UpdatePool(t *testing.T) {
 			name:   "error-update-pool",
 			poolID: urnPool,
 			pool: PoolModelRequest{
-				Name:                     "poule 2",
-				Description:              "poule description",
+				Name:                     testPoolPoule2,
+				Description:              testPoolPouleDesc,
 				GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 				Enabled:                  utils.ToPTR(true),
 				Algorithm:                "LEAST_CONNECTIONS",
@@ -1571,18 +1571,18 @@ func TestClient_UpdatePool(t *testing.T) {
 				PassiveMonitoringEnabled: utils.ToPTR(true),
 				HealthMonitors: []PoolModelHealthMonitor{
 					{
-						Name: "monitor HTTP",
+						Name: testPoolMonitorHTTP,
 						Type: PoolHealthMonitorTypeHTTP,
 					},
 					{
-						Name: "monitor TCP",
+						Name: testPoolMonitorTCP,
 						Type: PoolHealthMonitorTypeTCP,
 					},
 				},
 				Members: []PoolModelMember{
 					{
 						Enabled:               true,
-						IPAddress:             "192.168.0.1",
+						IPAddress:             testIPAddress,
 						Port:                  80,
 						Ratio:                 utils.ToPTR(1),
 						MarkedDownBy:          nil,
@@ -1595,7 +1595,7 @@ func TestClient_UpdatePool(t *testing.T) {
 				CommonNameCheckEnabled: utils.ToPTR(false), // false because CaCertificateRefs is nil.
 				DomainNames:            nil,                // nil because CommonNameCheckEnabled is false.
 				PersistenceProfile: &PoolModelPersistenceProfile{
-					Name:  "persistence profile",
+					Name:  testPoolPersistence,
 					Type:  PoolPersistenceProfileTypeClientIP,
 					Value: "",
 				},
@@ -1605,8 +1605,8 @@ func TestClient_UpdatePool(t *testing.T) {
 				clientCAV.EXPECT().GetAlbPoolById(urnPool).Return(&govcd.NsxtAlbPool{
 					NsxtAlbPool: &govcdtypes.NsxtAlbPool{
 						ID:                       urnPool,
-						Name:                     "pool1",
-						Description:              "pool1 description",
+						Name:                     testPoolName1,
+						Description:              testPoolName1Desc,
 						GatewayRef:               govcdtypes.OpenApiReference{ID: urnEdgeGateway},
 						Enabled:                  utils.ToPTR(true),
 						Algorithm:                "LEAST_CONNECTIONS",
@@ -1615,18 +1615,18 @@ func TestClient_UpdatePool(t *testing.T) {
 						PassiveMonitoringEnabled: utils.ToPTR(true),
 						HealthMonitors: []govcdtypes.NsxtAlbPoolHealthMonitor{
 							{
-								Name: "monitor HTTP",
+								Name: testPoolMonitorHTTP,
 								Type: "HTTP",
 							},
 							{
-								Name: "monitor TCP",
+								Name: testPoolMonitorTCP,
 								Type: "TCP",
 							},
 						},
 						Members: []govcdtypes.NsxtAlbPoolMember{
 							{
 								Enabled:               true,
-								IpAddress:             "192.168.0.1",
+								IpAddress:             testIPAddress,
 								Port:                  80,
 								Ratio:                 utils.ToPTR(1),
 								MarkedDownBy:          nil,
@@ -1641,7 +1641,7 @@ func TestClient_UpdatePool(t *testing.T) {
 						PersistenceProfile:     nil,
 						MemberCount:            1,
 						UpMemberCount:          1,
-						HealthMessage:          "All members are up",
+						HealthMessage:          testPoolMembersStatus,
 						VirtualServiceRefs:     nil,
 						SslEnabled:             utils.ToPTR(false),
 					},
@@ -1714,7 +1714,7 @@ func TestClient_DeletePool(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:   "refresh-error",
+			name:   testErrorRefreshShort,
 			poolID: urnPool,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))

--- a/v1/edgeloadbalancer/service_engine_group_test.go
+++ b/v1/edgeloadbalancer/service_engine_group_test.go
@@ -61,11 +61,11 @@ func TestClient_ListServiceEngineGroups(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   urnServiceEngineGroup,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   urnEdgeGateway,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -77,10 +77,10 @@ func TestClient_ListServiceEngineGroups(t *testing.T) {
 			expectedCertValue: []*ServiceEngineGroupModel{
 				{
 					ID:   urnServiceEngineGroup,
-					Name: "name",
+					Name: testName,
 					GatewayRef: &govcdtypes.OpenApiReference{
 						ID:   urnEdgeGateway,
-						Name: "edge_name",
+						Name: testEdgeName,
 					},
 					MaxVirtualServices:         utils.ToPTR(10),
 					MinVirtualServices:         utils.ToPTR(1),
@@ -91,7 +91,7 @@ func TestClient_ListServiceEngineGroups(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: urnEdgeGateway,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
@@ -101,7 +101,7 @@ func TestClient_ListServiceEngineGroups(t *testing.T) {
 			err:               errors.New("error"),
 		},
 		{
-			name:          "error-get-all-certificates",
+			name:          testErrorGetAllCerts,
 			edgeGatewayID: urnEdgeGateway,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -205,11 +205,11 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   urnServiceEngineGroup,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   urnEdgeGateway,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -220,10 +220,10 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 			},
 			expectedCertValue: &ServiceEngineGroupModel{
 				ID:   urnServiceEngineGroup,
-				Name: "name",
+				Name: testName,
 				GatewayRef: &govcdtypes.OpenApiReference{
 					ID:   urnEdgeGateway,
-					Name: "edge_name",
+					Name: testEdgeName,
 				},
 				MaxVirtualServices:         utils.ToPTR(10),
 				MinVirtualServices:         utils.ToPTR(1),
@@ -235,7 +235,7 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 		{
 			name:          "success-name",
 			edgeGatewayID: urnEdgeGateway,
-			nameOrID:      "name",
+			nameOrID:      testName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 
@@ -246,11 +246,11 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   urnServiceEngineGroup,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   urnEdgeGateway,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -261,10 +261,10 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 			},
 			expectedCertValue: &ServiceEngineGroupModel{
 				ID:   urnServiceEngineGroup,
-				Name: "name",
+				Name: testName,
 				GatewayRef: &govcdtypes.OpenApiReference{
 					ID:   urnEdgeGateway,
-					Name: "edge_name",
+					Name: testEdgeName,
 				},
 				MaxVirtualServices:         utils.ToPTR(10),
 				MinVirtualServices:         utils.ToPTR(1),
@@ -274,7 +274,7 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: urnEdgeGateway,
 			nameOrID:      urnServiceEngineGroup,
 			mockFunc: func() {
@@ -285,7 +285,7 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 			err:               errors.New("error"),
 		},
 		{
-			name:          "error-get-all-certificates",
+			name:          testErrorGetAllCerts,
 			edgeGatewayID: urnEdgeGateway,
 			nameOrID:      urnServiceEngineGroup,
 			mockFunc: func() {
@@ -312,11 +312,11 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   urnServiceEngineGroup,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   urnEdgeGateway,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -385,11 +385,11 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   serviceEngineID,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   edgeGatewayID,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -400,10 +400,10 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 			},
 			expectedValue: &ServiceEngineGroupModel{
 				ID:   serviceEngineID,
-				Name: "name",
+				Name: testName,
 				GatewayRef: &govcdtypes.OpenApiReference{
 					ID:   edgeGatewayID,
-					Name: "edge_name",
+					Name: testEdgeName,
 				},
 				MaxVirtualServices:         utils.ToPTR(10),
 				MinVirtualServices:         utils.ToPTR(1),
@@ -425,11 +425,11 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   serviceEngineID,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   edgeGatewayID,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -440,11 +440,11 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   serviceEngineID,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   edgeGatewayID,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -457,7 +457,7 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 			err:         errors.New("more than one service engine group available for edge gateway"),
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
@@ -467,7 +467,7 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:          "error-get-all-certificates",
+			name:          testErrorGetAllCerts,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)

--- a/v1/edgeloadbalancer/service_engine_group_test.go
+++ b/v1/edgeloadbalancer/service_engine_group_test.go
@@ -49,7 +49,7 @@ func TestClient_ListServiceEngineGroups(t *testing.T) {
 		err               error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			edgeGatewayID: urnEdgeGateway,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -192,7 +192,7 @@ func TestClient_GetServiceEngineGroup(t *testing.T) {
 		nameOrID          string
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			edgeGatewayID: urnEdgeGateway,
 			nameOrID:      urnServiceEngineGroup,
 			mockFunc: func() {
@@ -373,7 +373,7 @@ func TestClient_GetFirstServiceEngineGroup(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)

--- a/v1/edgeloadbalancer/testdata_test.go
+++ b/v1/edgeloadbalancer/testdata_test.go
@@ -48,6 +48,7 @@ const (
 	testHeaderValueCurl    = "curl/7.64.1"
 	testHeaderValueTest    = "test"
 	testHeaderValue1       = "value1"
+	testHeaderValue2       = "value2"
 
 	// Cookie fixtures.
 	testCookieName  = "session_id"

--- a/v1/edgeloadbalancer/testdata_test.go
+++ b/v1/edgeloadbalancer/testdata_test.go
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package edgeloadbalancer
+
+// Shared test constants used across all test files in this package.
+const (
+	// Virtual service fixtures.
+	testSuccess             = "success"
+	testVirtualServiceName1 = "virtualServiceName1"
+	testVirtualServiceDesc1 = "virtualServiceDescription1"
+	testVirtualServiceName2 = "virtualServiceName2"
+	testVirtualServiceDesc2 = "virtualServiceDescription2"
+	testRuleName            = "ruleName"
+	testRuleName2           = "ruleName2"
+	testRuleName3           = "ruleName3"
+
+	// Network fixtures.
+	testIPAddress = "192.168.0.1"
+	testIPSingle  = "12.23.34.45"
+	testIPCIDR    = "12.23.34.0/24"
+	testIPRange   = "12.23.34.0-12.23.34.100"
+
+	// HTTP path fixtures.
+	testPath1   = "/path1"
+	testPath2   = "/path2"
+	testNewPath = "/newpath"
+
+	// HTTP query param fixtures.
+	testQuery1 = "key1=value1"
+	testQuery2 = "key2=value2"
+
+	// HTTP header fixtures.
+	testHeaderUserAgent       = "User-Agent"
+	testHeaderAccept          = "Accept"
+	testHeaderXForwardedFor   = "X-Forwarded-For"
+	testHeaderXForwardedProto = "X-Forwarded-Proto"
+	testHeaderXCustom         = "X-Custom-Header"
+
+	// HTTP header value fixtures.
+	testHeaderValueMozilla = "Mozilla/5.0"
+	testHeaderValueCurl    = "curl/7.64.1"
+	testHeaderValueTest    = "test"
+	testHeaderValue1       = "value1"
+
+	// Cookie fixtures.
+	testCookieName  = "session_id"
+	testCookieValue = "abc123"
+
+	// Domain/redirect fixtures.
+	testDomain       = "example.com"
+	testRedirectCode = "301-303"
+
+	// Error state fixtures.
+	testErrorRefresh         = "error-refresh"
+	testErrorVSValidation    = "error-virtualserviceValidation"
+	testErrorGetVS           = "error-getVirtualService"
+	testErrorValidationModel = "error-validation-model"
+	testErrorDelete          = "error-delete"
+	testErrorRefreshShort    = "refresh-error"
+	testErrorGetShort        = "error-get"
+	testErrorValidation      = "error-validation"
+	testErrorGetAllCerts     = "error-get-all-certificates"
+
+	// Pool fixtures.
+	testPoolName1            = "pool1"
+	testPoolName1Desc        = "pool1 description"
+	testPoolName2            = "pool2"
+	testPoolName2Desc        = "pool2 description"
+	testPoolMonitorHTTP      = "monitor HTTP"
+	testPoolMonitorTCP       = "monitor TCP"
+	testPoolPersistence      = "persistence profile"
+	testPoolMembersStatus    = "All members are up"
+	testPoolPoule2           = "poule 2"
+	testPoolPouleDesc        = "poule description"
+	testPoolParamEdgeEmpty   = "param-edgeGatewayID-empty"
+	testPoolParamEdgeInvalid = "param-edgeGatewayID-invalid-id"
+
+	// Service engine group fixtures.
+	testEdgeName = "edge_name"
+
+	// Shared name fixture.
+	testName = "name"
+
+	// Security policy fixtures.
+	testJSONBody   = "{\"key\":\"value\"}"
+	testBase64Body = "eyJrZXkiOiJ2YWx1ZSJ9Cg=="
+
+	// Content type fixtures.
+	testContentTypeJSON = "application/json"
+	testContentTypeHTML = "text/html"
+)

--- a/v1/edgeloadbalancer/virtual_service_test.go
+++ b/v1/edgeloadbalancer/virtual_service_test.go
@@ -41,8 +41,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "success",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -54,7 +54,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -62,8 +62,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-app-profile",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTE"),
 				PoolID:               poolID,
@@ -75,7 +75,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'ApplicationProfile'"),
@@ -83,8 +83,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-invalid-pool-id",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               edgeGatewayID,
@@ -96,7 +96,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'PoolID' failed on the 'urn'"),
@@ -104,8 +104,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-invalid-edgegateway-id",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -116,7 +116,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'EdgeGatewayID' failed on the 'urn'"),
@@ -124,8 +124,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-invalid-certificate-id",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTPS"),
 				PoolID:             poolID,
@@ -137,7 +137,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'CertificateID' failed on the 'urn'"),
@@ -145,8 +145,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-invalid-virtual-ip",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -165,14 +165,14 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-no-service-ports",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
 				EdgeGatewayID:      edgeGatewayID,
 				ServicePorts:       []VirtualServiceModelServicePort{},
-				VirtualIPAddress:   "192.168.0.1",
+				VirtualIPAddress:   testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'ServicePorts' failed on the 'gte'"),
@@ -180,8 +180,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-service-port-start",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -192,7 +192,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'Start' failed on the 'lte'"),
@@ -200,8 +200,8 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		{
 			name: "error-service-port-end-not-gt-start",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -212,7 +212,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 						End:   utils.ToPTR(8070),
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			expectedErr: true,
 			err:         errors.New("Field validation for 'End' failed on the 'gtfield'"),
@@ -264,15 +264,15 @@ func TestClient_GetVirtualService(t *testing.T) {
 			name:               "success-http-by-name",
 			edgeGatewayID:      edgeGatewayID,
 			virtualServiceID:   virtualServiceID,
-			virtualServiceName: "virtualServiceName1",
-			byNameOrID:         "name",
+			virtualServiceName: testVirtualServiceName1,
+			byNameOrID:         testName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
-				clientCAV.EXPECT().GetAlbVirtualServiceByName(edgeGatewayID, "virtualServiceName1").Return(&govcd.NsxtAlbVirtualService{
+				clientCAV.EXPECT().GetAlbVirtualServiceByName(edgeGatewayID, testVirtualServiceName1).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTP",
@@ -296,7 +296,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -305,8 +305,8 @@ func TestClient_GetVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -324,7 +324,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -336,15 +336,15 @@ func TestClient_GetVirtualService(t *testing.T) {
 			name:               "success-https-by-id",
 			edgeGatewayID:      edgeGatewayID,
 			virtualServiceID:   virtualServiceID,
-			virtualServiceName: "virtualServiceName2",
+			virtualServiceName: testVirtualServiceName2,
 			byNameOrID:         "id",
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -371,7 +371,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -380,8 +380,8 @@ func TestClient_GetVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName2",
-				Description:        "virtualServiceDescription2",
+				Name:               testVirtualServiceName2,
+				Description:        testVirtualServiceDesc2,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTPS"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -402,7 +402,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -412,15 +412,15 @@ func TestClient_GetVirtualService(t *testing.T) {
 		// 	name:               "success-http-by-name-with-service-port-type-empty",
 		// 	edgeGatewayID:      edgeGatewayID,
 		// 	virtualServiceID:   virtualServiceID,
-		// 	virtualServiceName: "virtualServiceName1",
-		// 	byNameOrID:         "name",
+		// 	virtualServiceName: testVirtualServiceName1,
+		// 	byNameOrID:         testName,
 		// 	mockFunc: func() {
 		// 		clientCAV.EXPECT().Refresh().Return(nil)
-		// 		clientCAV.EXPECT().GetAlbVirtualServiceByName(edgeGatewayID, "virtualServiceName1").Return(&govcd.NsxtAlbVirtualService{
+		// 		clientCAV.EXPECT().GetAlbVirtualServiceByName(edgeGatewayID, testVirtualServiceName1).Return(&govcd.NsxtAlbVirtualService{
 		// 			NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 		// 				ID:          virtualServiceID,
-		// 				Name:        "virtualServiceName1",
-		// 				Description: "virtualServiceDescription1",
+		// 				Name:        testVirtualServiceName1,
+		// 				Description: testVirtualServiceDesc1,
 		// 				Enabled:     utils.ToPTR(true),
 		// 				ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 		// 					Type: "HTTP",
@@ -442,7 +442,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 		// 						TcpUdpProfile: nil,
 		// 					},
 		// 				},
-		// 				VirtualIpAddress:      "192.168.0.1",
+		// 				VirtualIpAddress:      testIPAddress,
 		// 				HealthStatus:          "UP",
 		// 				HealthMessage:         "OK",
 		// 				DetailedHealthMessage: "OK",
@@ -451,8 +451,8 @@ func TestClient_GetVirtualService(t *testing.T) {
 		// 	},
 		// 	expectedValue: &VirtualServiceModel{
 		// 		ID:                 virtualServiceID,
-		// 		Name:               "virtualServiceName1",
-		// 		Description:        "virtualServiceDescription1",
+		// 		Name:               testVirtualServiceName1,
+		// 		Description:        testVirtualServiceDesc1,
 		// 		Enabled:            utils.ToPTR(true),
 		// 		ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 		// 		PoolRef: govcdtypes.OpenApiReference{
@@ -470,7 +470,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 		// 				End:   nil,
 		// 			},
 		// 		},
-		// 		VirtualIPAddress:      "192.168.0.1",
+		// 		VirtualIPAddress:      testIPAddress,
 		// 		HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 		// 		HealthMessage:         "OK",
 		// 		DetailedHealthMessage: "OK",
@@ -509,7 +509,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 			err:              errors.New("edgeGatewayID has invalid format. Please provide a valid edgeGatewayID"),
 		},
 		{
-			name:             "refresh-error",
+			name:             testErrorRefreshShort,
 			edgeGatewayID:    edgeGatewayID,
 			virtualServiceID: virtualServiceID,
 			byNameOrID:       "id",
@@ -521,7 +521,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:             "error-get",
+			name:             testErrorGetShort,
 			edgeGatewayID:    edgeGatewayID,
 			virtualServiceID: virtualServiceID,
 			byNameOrID:       "id",
@@ -594,8 +594,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 					{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID,
-							Name:        "virtualServiceName1",
-							Description: "virtualServiceDescription1",
+							Name:        testVirtualServiceName1,
+							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -605,8 +605,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 					{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID2,
-							Name:        "virtualServiceName2",
-							Description: "virtualServiceDescription2",
+							Name:        testVirtualServiceName2,
+							Description: testVirtualServiceDesc2,
 							Enabled:     utils.ToPTR(true),
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -617,8 +617,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTP",
@@ -642,7 +642,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -651,8 +651,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID2).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID2,
-						Name:        "virtualServiceName2",
-						Description: "virtualServiceDescription2",
+						Name:        testVirtualServiceName2,
+						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -689,8 +689,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 			expectedValue: []*VirtualServiceModel{
 				{
 					ID:                 virtualServiceID,
-					Name:               "virtualServiceName1",
-					Description:        "virtualServiceDescription1",
+					Name:               testVirtualServiceName1,
+					Description:        testVirtualServiceDesc1,
 					Enabled:            utils.ToPTR(true),
 					ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 					PoolRef: govcdtypes.OpenApiReference{
@@ -708,15 +708,15 @@ func TestClient_ListVirtualServices(t *testing.T) {
 							End:   nil,
 						},
 					},
-					VirtualIPAddress:      "192.168.0.1",
+					VirtualIPAddress:      testIPAddress,
 					HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 					HealthMessage:         "OK",
 					DetailedHealthMessage: "OK",
 				},
 				{
 					ID:                 virtualServiceID2,
-					Name:               "virtualServiceName2",
-					Description:        "virtualServiceDescription2",
+					Name:               testVirtualServiceName2,
+					Description:        testVirtualServiceDesc2,
 					Enabled:            utils.ToPTR(true),
 					ApplicationProfile: VirtualServiceModelApplicationProfile("HTTPS"),
 					PoolRef: govcdtypes.OpenApiReference{
@@ -755,8 +755,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 					{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID,
-							Name:        "virtualServiceName1",
-							Description: "virtualServiceDescription1",
+							Name:        testVirtualServiceName1,
+							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -766,8 +766,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 					{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID2,
-							Name:        "virtualServiceName2",
-							Description: "virtualServiceDescription2",
+							Name:        testVirtualServiceName2,
+							Description: testVirtualServiceDesc2,
 							Enabled:     utils.ToPTR(true),
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -778,8 +778,8 @@ func TestClient_ListVirtualServices(t *testing.T) {
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTP",
@@ -803,7 +803,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -816,7 +816,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 			err:           errors.New("error retrieving complete virtual service: error"),
 		},
 		{
-			name:          "refresh-error",
+			name:          testErrorRefreshShort,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
@@ -826,7 +826,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:          "error-get",
+			name:          testErrorGetShort,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -837,7 +837,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name:          "param-edgeGatewayID-empty",
+			name:          testPoolParamEdgeEmpty,
 			edgeGatewayID: "",
 			mockFunc: func() {
 			},
@@ -846,7 +846,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 			err:           errors.New("edgeGatewayID is empty. Please provide a valid edgeGatewayID"),
 		},
 		{
-			name:          "param-edgeGatewayID-invalid-id",
+			name:          testPoolParamEdgeInvalid,
 			edgeGatewayID: "1234",
 			mockFunc: func() {
 			},
@@ -903,8 +903,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "success-l4tcp",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("L4_UDP"),
 				PoolID:               poolID,
@@ -916,15 +916,15 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().CreateNsxtAlbVirtualService(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbVirtualService{})).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "L4",
@@ -948,7 +948,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -957,8 +957,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("L4_UDP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -976,7 +976,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -987,8 +987,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "success-l4tcp",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("L4_TCP"),
 				PoolID:               poolID,
@@ -1000,15 +1000,15 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().CreateNsxtAlbVirtualService(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbVirtualService{})).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "L4",
@@ -1032,7 +1032,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1041,8 +1041,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("L4_TCP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1060,7 +1060,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1071,8 +1071,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "success-http",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1084,15 +1084,15 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().CreateNsxtAlbVirtualService(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbVirtualService{})).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTP",
@@ -1116,7 +1116,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1125,8 +1125,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1144,7 +1144,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1155,8 +1155,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "success-https",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTPS"),
 				PoolID:               poolID,
@@ -1169,15 +1169,15 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().CreateNsxtAlbVirtualService(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbVirtualService{})).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1204,7 +1204,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1213,8 +1213,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTPS"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1235,7 +1235,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1246,8 +1246,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "success-http-with-empty-service-engine-group",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -1258,7 +1258,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(2)
@@ -1269,11 +1269,11 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   serviceEngineID,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   edgeGatewayID,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -1284,8 +1284,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 				clientCAV.EXPECT().CreateNsxtAlbVirtualService(gomock.AssignableToTypeOf(&govcdtypes.NsxtAlbVirtualService{})).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTP",
@@ -1309,7 +1309,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1318,8 +1318,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1337,7 +1337,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1348,8 +1348,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "error-http-with-empty-service-engine-group",
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -1360,7 +1360,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(2)
@@ -1372,7 +1372,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			err:         errors.New("error"),
 		},
 		{
-			name:          "error-validation",
+			name:          testErrorValidation,
 			virtualModel:  VirtualServiceModelRequest{},
 			mockFunc:      func() {},
 			expectedValue: nil,
@@ -1382,8 +1382,8 @@ func TestClient_CreateVirtualService(t *testing.T) {
 		{
 			name: "error-create-virtual-service",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1395,7 +1395,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -1406,10 +1406,10 @@ func TestClient_CreateVirtualService(t *testing.T) {
 			err:           errors.New("error"),
 		},
 		{
-			name: "error-refresh",
+			name: testErrorRefresh,
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1421,7 +1421,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
@@ -1481,8 +1481,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			name:             "success-http",
 			virtualServiceID: virtualServiceID,
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1494,15 +1494,15 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1529,7 +1529,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1540,8 +1540,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 					return &govcd.NsxtAlbVirtualService{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID,
-							Name:        "virtualServiceName1",
-							Description: "virtualServiceDescription1",
+							Name:        testVirtualServiceName1,
+							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 								Type: "HTTP",
@@ -1565,7 +1565,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 									},
 								},
 							},
-							VirtualIpAddress:      "192.168.0.1",
+							VirtualIpAddress:      testIPAddress,
 							HealthStatus:          "UP",
 							HealthMessage:         "OK",
 							DetailedHealthMessage: "OK",
@@ -1575,8 +1575,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1594,7 +1594,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1606,8 +1606,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			name:             "success-http-without-service-engine-group",
 			virtualServiceID: virtualServiceID,
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -1618,15 +1618,15 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(2)
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1653,7 +1653,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1667,11 +1667,11 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						NsxtAlbServiceEngineGroupAssignment: &govcdtypes.NsxtAlbServiceEngineGroupAssignment{
 							ServiceEngineGroupRef: &govcdtypes.OpenApiReference{
 								ID:   serviceEngineID,
-								Name: "name",
+								Name: testName,
 							},
 							GatewayRef: &govcdtypes.OpenApiReference{
 								ID:   edgeGatewayID,
-								Name: "edge_name",
+								Name: testEdgeName,
 							},
 							MaxVirtualServices:         utils.ToPTR(10),
 							MinVirtualServices:         utils.ToPTR(1),
@@ -1684,8 +1684,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 					return &govcd.NsxtAlbVirtualService{
 						NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 							ID:          virtualServiceID,
-							Name:        "virtualServiceName1",
-							Description: "virtualServiceDescription1",
+							Name:        testVirtualServiceName1,
+							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 								Type: "HTTP",
@@ -1709,7 +1709,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 									},
 								},
 							},
-							VirtualIpAddress:      "192.168.0.1",
+							VirtualIpAddress:      testIPAddress,
 							HealthStatus:          "UP",
 							HealthMessage:         "OK",
 							DetailedHealthMessage: "OK",
@@ -1719,8 +1719,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			},
 			expectedValue: &VirtualServiceModel{
 				ID:                 virtualServiceID,
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolRef: govcdtypes.OpenApiReference{
@@ -1738,7 +1738,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress:      "192.168.0.1",
+				VirtualIPAddress:      testIPAddress,
 				HealthStatus:          VirtualServiceModelHealthStatus("UP"),
 				HealthMessage:         "OK",
 				DetailedHealthMessage: "OK",
@@ -1750,8 +1750,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			name:             "success-http-without-service-engine-group",
 			virtualServiceID: virtualServiceID,
 			virtualModel: VirtualServiceModelRequest{
-				Name:               "virtualServiceName1",
-				Description:        "virtualServiceDescription1",
+				Name:               testVirtualServiceName1,
+				Description:        testVirtualServiceDesc1,
 				Enabled:            utils.ToPTR(true),
 				ApplicationProfile: VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:             poolID,
@@ -1762,15 +1762,15 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(2)
 				clientCAV.EXPECT().GetAlbVirtualServiceById(virtualServiceID).Return(&govcd.NsxtAlbVirtualService{
 					NsxtAlbVirtualService: &govcdtypes.NsxtAlbVirtualService{
 						ID:          virtualServiceID,
-						Name:        "virtualServiceName1",
-						Description: "virtualServiceDescription1",
+						Name:        testVirtualServiceName1,
+						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
 							Type: "HTTPS",
@@ -1797,7 +1797,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								},
 							},
 						},
-						VirtualIpAddress:      "192.168.0.1",
+						VirtualIpAddress:      testIPAddress,
 						HealthStatus:          "UP",
 						HealthMessage:         "OK",
 						DetailedHealthMessage: "OK",
@@ -1826,22 +1826,22 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 			err:              errors.New("virtualServiceID has invalid format. Please provide a valid virtualServiceID"),
 		},
 		{
-			name:             "error-validation",
+			name:             testErrorValidation,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc:         func() {},
 			err:              errors.New("Error:Field validation"),
 		},
 		{
-			name:             "error-refresh",
+			name:             testErrorRefresh,
 			expectedErr:      true,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1853,15 +1853,15 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			err: errors.New("error"),
 		},
 		{
 			name: "error-get-virtual-service",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1873,7 +1873,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -1887,8 +1887,8 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 		{
 			name: "error-update-virtual-service",
 			virtualModel: VirtualServiceModelRequest{
-				Name:                 "virtualServiceName1",
-				Description:          "virtualServiceDescription1",
+				Name:                 testVirtualServiceName1,
+				Description:          testVirtualServiceDesc1,
 				Enabled:              utils.ToPTR(true),
 				ApplicationProfile:   VirtualServiceModelApplicationProfile("HTTP"),
 				PoolID:               poolID,
@@ -1900,7 +1900,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						End:   nil,
 					},
 				},
-				VirtualIPAddress: "192.168.0.1",
+				VirtualIPAddress: testIPAddress,
 			},
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
@@ -1974,7 +1974,7 @@ func TestClient_DeleteVirtualService(t *testing.T) {
 			err:         nil,
 		},
 		{
-			name:             "refresh-error",
+			name:             testErrorRefreshShort,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))

--- a/v1/edgeloadbalancer/virtual_service_test.go
+++ b/v1/edgeloadbalancer/virtual_service_test.go
@@ -39,7 +39,7 @@ func TestVirtualServiceRequestValidation(t *testing.T) {
 		err          error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			virtualModel: VirtualServiceModelRequest{
 				Name:                 testVirtualServiceName1,
 				Description:          testVirtualServiceDesc1,
@@ -275,7 +275,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTP",
+							Type: string(VirtualServiceApplicationProfileHTTP),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -292,7 +292,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(false),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -347,7 +347,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -367,7 +367,7 @@ func TestClient_GetVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -586,7 +586,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			edgeGatewayID: edgeGatewayID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil).Times(3)
@@ -621,7 +621,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTP",
+							Type: string(VirtualServiceApplicationProfileHTTP),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -638,7 +638,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(false),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -655,7 +655,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 						Description: testVirtualServiceDesc2,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -675,7 +675,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -782,7 +782,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTP",
+							Type: string(VirtualServiceApplicationProfileHTTP),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -799,7 +799,7 @@ func TestClient_ListVirtualServices(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(false),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1095,7 +1095,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTP",
+							Type: string(VirtualServiceApplicationProfileHTTP),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1112,7 +1112,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(false),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1180,7 +1180,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1200,7 +1200,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1288,7 +1288,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTP",
+							Type: string(VirtualServiceApplicationProfileHTTP),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1305,7 +1305,7 @@ func TestClient_CreateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(false),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1505,7 +1505,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1525,7 +1525,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1544,7 +1544,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-								Type: "HTTP",
+								Type: string(VirtualServiceApplicationProfileHTTP),
 							},
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -1561,7 +1561,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 									PortEnd:    nil,
 									SslEnabled: utils.ToPTR(false),
 									TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-										Type: "TCP_PROXY",
+										Type: string(virtualServiceServicePortTypeTCPProxy),
 									},
 								},
 							},
@@ -1629,7 +1629,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1649,7 +1649,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1688,7 +1688,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 							Description: testVirtualServiceDesc1,
 							Enabled:     utils.ToPTR(true),
 							ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-								Type: "HTTP",
+								Type: string(VirtualServiceApplicationProfileHTTP),
 							},
 							GatewayRef: govcdtypes.OpenApiReference{
 								ID: edgeGatewayID,
@@ -1705,7 +1705,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 									PortEnd:    nil,
 									SslEnabled: utils.ToPTR(false),
 									TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-										Type: "TCP_PROXY",
+										Type: string(virtualServiceServicePortTypeTCPProxy),
 									},
 								},
 							},
@@ -1773,7 +1773,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 						Description: testVirtualServiceDesc1,
 						Enabled:     utils.ToPTR(true),
 						ApplicationProfile: govcdtypes.NsxtAlbVirtualServiceApplicationProfile{
-							Type: "HTTPS",
+							Type: string(VirtualServiceApplicationProfileHTTPS),
 						},
 						GatewayRef: govcdtypes.OpenApiReference{
 							ID: edgeGatewayID,
@@ -1793,7 +1793,7 @@ func TestClient_UpdateVirtualService(t *testing.T) {
 								PortEnd:    nil,
 								SslEnabled: utils.ToPTR(true),
 								TcpUdpProfile: &govcdtypes.NsxtAlbVirtualServicePortTcpUdpProfile{
-									Type: "TCP_PROXY",
+									Type: string(virtualServiceServicePortTypeTCPProxy),
 								},
 							},
 						},
@@ -1957,7 +1957,7 @@ func TestClient_DeleteVirtualService(t *testing.T) {
 		err              error
 	}{
 		{
-			name:             "success",
+			name:             testSuccess,
 			virtualServiceID: virtualServiceID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)

--- a/v1/iam/user_test.go
+++ b/v1/iam/user_test.go
@@ -24,6 +24,8 @@ import (
 	mock "github.com/orange-cloudavenue/cloudavenue-sdk-go/v1/iam/mock"
 )
 
+const testUserName = "test"
+
 func TestClient_CreateLocalUser(t *testing.T) {
 	// Mock controller.
 	ctrl := gomock.NewController(t)
@@ -54,9 +56,9 @@ func TestClient_CreateLocalUser(t *testing.T) {
 				func() {
 					clientAdminOrg.EXPECT().CreateUser(gomock.Any()).Return(&govcd.OrgUser{
 						User: &govcdtypes.User{
-							Name: "test",
+							Name: testUserName,
 							Role: &govcdtypes.Reference{
-								Name: "test",
+								Name: testUserName,
 							},
 							ID: urn.VcloudPrefix + urn.User.String() + uuid.NewString(),
 						},
@@ -67,23 +69,23 @@ func TestClient_CreateLocalUser(t *testing.T) {
 				},
 				func() {
 					clientAdminOrg.EXPECT().GetRoleReference(gomock.Any()).Return(&govcdtypes.Reference{
-						Name: "test",
+						Name: testUserName,
 						HREF: "https://foo.bar/api/admin/role/test",
 					}, nil)
 				},
 			},
 			userValue: LocalUser{
 				User: User{
-					Name:     "test",
-					RoleName: "test",
+					Name:     testUserName,
+					RoleName: testUserName,
 				},
 
 				Password: "1234567",
 			},
 			expectedUserValue: &LocalUser{
 				User: User{
-					Name:     "test",
-					RoleName: "test",
+					Name:     testUserName,
+					RoleName: testUserName,
 					ID:       urn.VcloudPrefix + urn.User.String(),
 				},
 			},
@@ -100,8 +102,8 @@ func TestClient_CreateLocalUser(t *testing.T) {
 			},
 			userValue: LocalUser{
 				User: User{
-					Name:     "test",
-					RoleName: "test",
+					Name:     testUserName,
+					RoleName: testUserName,
 				},
 				Password: "",
 			},
@@ -130,15 +132,15 @@ func TestClient_CreateLocalUser(t *testing.T) {
 				},
 				func() {
 					clientAdminOrg.EXPECT().GetRoleReference(gomock.Any()).Return(&govcdtypes.Reference{
-						Name: "test",
+						Name: testUserName,
 						HREF: "https://foo.bar/api/admin/role/test",
 					}, nil)
 				},
 			},
 			userValue: LocalUser{
 				User: User{
-					Name:     "test",
-					RoleName: "test",
+					Name:     testUserName,
+					RoleName: testUserName,
 				},
 				Password: "1234567",
 			},
@@ -156,8 +158,8 @@ func TestClient_CreateLocalUser(t *testing.T) {
 			},
 			userValue: LocalUser{
 				User: User{
-					Name:     "test",
-					RoleName: "test",
+					Name:     testUserName,
+					RoleName: testUserName,
 				},
 				Password: "1234567",
 			},
@@ -225,9 +227,9 @@ func TestClient_GetUser(t *testing.T) {
 				func() {
 					clientAdminOrg.EXPECT().GetUserByNameOrId(gomock.Any(), true).Return(&govcd.OrgUser{
 						User: &govcdtypes.User{
-							Name: "test",
+							Name: testUserName,
 							Role: &govcdtypes.Reference{
-								Name: "test",
+								Name: testUserName,
 							},
 							ProviderType: govcd.OrgUserProviderIntegrated,
 							ID:           urn.VcloudPrefix + urn.User.String() + uuid.NewString(),
@@ -238,10 +240,10 @@ func TestClient_GetUser(t *testing.T) {
 					clientCAV.EXPECT().Refresh().Return(nil)
 				},
 			},
-			nameOrID: "test",
+			nameOrID: testUserName,
 			expectedUserValue: &User{
-				Name:     "test",
-				RoleName: "test",
+				Name:     testUserName,
+				RoleName: testUserName,
 				ID:       urn.VcloudPrefix + urn.User.String(),
 			},
 			expectedErr: false,
@@ -253,9 +255,9 @@ func TestClient_GetUser(t *testing.T) {
 				func() {
 					clientAdminOrg.EXPECT().GetUserByNameOrId(gomock.Any(), true).Return(&govcd.OrgUser{
 						User: &govcdtypes.User{
-							Name: "test",
+							Name: testUserName,
 							Role: &govcdtypes.Reference{
-								Name: "test",
+								Name: testUserName,
 							},
 							ProviderType: govcd.OrgUserProviderSAML,
 							ID:           urn.VcloudPrefix + urn.User.String() + uuid.NewString(),
@@ -266,10 +268,10 @@ func TestClient_GetUser(t *testing.T) {
 					clientCAV.EXPECT().Refresh().Return(nil)
 				},
 			},
-			nameOrID: "test",
+			nameOrID: testUserName,
 			expectedUserValue: &User{
-				Name:     "test",
-				RoleName: "test",
+				Name:     testUserName,
+				RoleName: testUserName,
 				ID:       urn.VcloudPrefix + urn.User.String(),
 			},
 			expectedErr: false,
@@ -283,7 +285,7 @@ func TestClient_GetUser(t *testing.T) {
 					clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 				},
 			},
-			nameOrID:    "test",
+			nameOrID:    testUserName,
 			expectedErr: true,
 		},
 		{
@@ -296,7 +298,7 @@ func TestClient_GetUser(t *testing.T) {
 					clientCAV.EXPECT().Refresh().Return(nil)
 				},
 			},
-			nameOrID:    "test",
+			nameOrID:    testUserName,
 			expectedErr: true,
 		},
 	}

--- a/v1/iam/user_types.go
+++ b/v1/iam/user_types.go
@@ -92,7 +92,7 @@ func (u User) GetRoleName() string {
 func toGoVCDTypeUser(user any, roleReference *govcdtypes.Reference) *govcdtypes.User {
 	// toGoVCDTypeUser converts a user to a go-vcd user by reflecting.
 	x := reflect.ValueOf(user)
-	if x.Kind() == reflect.Ptr {
+	if x.Kind() == reflect.Pointer {
 		x = x.Elem()
 	}
 

--- a/v1/netbackup/netbackup_machines.go
+++ b/v1/netbackup/netbackup_machines.go
@@ -20,6 +20,8 @@ import (
 	commonnetbackup "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/netbackup"
 )
 
+const machineIDKey = "machineID"
+
 type MachineClient struct{}
 
 // Machine - Is the response structure for the Machines APIs.
@@ -340,7 +342,7 @@ func (m *Machine) ListProtectionLevels() (resp *ProtectionLevels, err error) {
 	r, err := c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"machineID": fmt.Sprintf("%d", m.GetID()),
+			machineIDKey: fmt.Sprintf("%d", m.GetID()),
 		}).
 		SetResult(&protectionLevelAppliedResponse{}).
 		Get("/v6/machines/{machineID}/protected")
@@ -395,7 +397,7 @@ func (m *Machine) Protect(req ProtectUnprotectRequest) (job *commonnetbackup.Job
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"machineID": fmt.Sprintf("%d", m.GetID()),
+			machineIDKey: fmt.Sprintf("%d", m.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),
@@ -447,7 +449,7 @@ func (m *Machine) Unprotect(req ProtectUnprotectRequest) (job *commonnetbackup.J
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"machineID": fmt.Sprintf("%d", m.GetID()),
+			machineIDKey: fmt.Sprintf("%d", m.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),

--- a/v1/netbackup/netbackup_protection_level_get.go
+++ b/v1/netbackup/netbackup_protection_level_get.go
@@ -18,6 +18,8 @@ import (
 	commonnetbackup "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/netbackup"
 )
 
+const protectionLevelIDKey = "ProtectionLevelId"
+
 type getProtectionLevelResponse struct {
 	Data ProtectionLevel `json:"data,omitempty"`
 }
@@ -57,22 +59,22 @@ func (p *ProtectionLevelClient) getProtectionLevelByID(req getProtectionLevelByI
 	case req.VAppID != nil:
 		r, err = hReq.
 			SetPathParams(map[string]string{
-				"VAppId":            fmt.Sprintf("%d", *req.VAppID),
-				"ProtectionLevelId": fmt.Sprintf("%d", *req.ProtectionLevelID),
+				"VAppId":             fmt.Sprintf("%d", *req.VAppID),
+				protectionLevelIDKey: fmt.Sprintf("%d", *req.ProtectionLevelID),
 			}).
 			Get("/v6/vcloud/vapps/{VAppId}/protection/levels/{ProtectionLevelId}")
 	case req.VDCID != nil:
 		r, err = hReq.
 			SetPathParams(map[string]string{
-				"VdcId":             fmt.Sprintf("%d", *req.VDCID),
-				"ProtectionLevelId": fmt.Sprintf("%d", *req.ProtectionLevelID),
+				"VdcId":              fmt.Sprintf("%d", *req.VDCID),
+				protectionLevelIDKey: fmt.Sprintf("%d", *req.ProtectionLevelID),
 			}).
 			Get("/v6/vcloud/vdcs/{VdcId}/protection/levels/{ProtectionLevelId}")
 	case req.MachineID != nil:
 		r, err = hReq.
 			SetPathParams(map[string]string{
-				"MachineId":         fmt.Sprintf("%d", *req.MachineID),
-				"ProtectionLevelId": fmt.Sprintf("%d", *req.ProtectionLevelID),
+				"MachineId":          fmt.Sprintf("%d", *req.MachineID),
+				protectionLevelIDKey: fmt.Sprintf("%d", *req.ProtectionLevelID),
 			}).
 			Get("/v6/machines/{MachineId}/protection/levels/{ProtectionLevelId}")
 	}

--- a/v1/netbackup/netbackup_vcloud_org.go
+++ b/v1/netbackup/netbackup_vcloud_org.go
@@ -107,7 +107,7 @@ func (v *VcloudClient) GetOrg(id int) (resp *Org, err error) {
 		SetResult(&orgResponse{}).
 		SetError(commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", id),
+			vAppIDKey: fmt.Sprintf("%d", id),
 		}).
 		Get("/v6/vcloud/orgs/{orgID}")
 	if err != nil {

--- a/v1/netbackup/netbackup_vcloud_vapp.go
+++ b/v1/netbackup/netbackup_vcloud_vapp.go
@@ -20,6 +20,8 @@ import (
 	commonnetbackup "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/netbackup"
 )
 
+const vAppIDKey = "vAppID"
+
 // VApp - Is the response structure for the GetVApp API.
 type VApp struct {
 	ID               int    `json:"Id,omitempty"`
@@ -107,7 +109,7 @@ func (v *VcloudClient) GetVAppByID(id int) (resp *VApp, err error) {
 		SetResult(&VAppResponse{}).
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", id),
+			vAppIDKey: fmt.Sprintf("%d", id),
 		}).
 		Get("/v6/vcloud/vapps/{vAppID}")
 	if err != nil {
@@ -222,7 +224,7 @@ func (v *VcloudClient) GetVAppMachines(vAppID int) (resp *GetVAppMachinesRespons
 		SetResult(&GetVAppMachinesResponse{}).
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", vAppID),
+			vAppIDKey: fmt.Sprintf("%d", vAppID),
 		}).
 		Get("/v6/vcloud/vapps/{vAppID}/machines")
 	if err != nil {
@@ -274,7 +276,7 @@ func (vApp *VApp) ListProtectionLevels() (resp *ProtectionLevels, err error) {
 	r, err := c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", vApp.GetID()),
+			vAppIDKey: fmt.Sprintf("%d", vApp.GetID()),
 		}).
 		SetResult(&protectionLevelAppliedResponse{}).
 		Get("/v6/vcloud/vapps/{vAppID}/protected")
@@ -329,7 +331,7 @@ func (vApp *VApp) Protect(req ProtectUnprotectRequest) (job *commonnetbackup.Job
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", vApp.GetID()),
+			vAppIDKey: fmt.Sprintf("%d", vApp.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),
@@ -381,7 +383,7 @@ func (vApp *VApp) Unprotect(req ProtectUnprotectRequest) (job *commonnetbackup.J
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vAppID": fmt.Sprintf("%d", vApp.GetID()),
+			vAppIDKey: fmt.Sprintf("%d", vApp.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),

--- a/v1/netbackup/netbackup_vcloud_vdc.go
+++ b/v1/netbackup/netbackup_vcloud_vdc.go
@@ -19,6 +19,8 @@ import (
 	commonnetbackup "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/netbackup"
 )
 
+const vdcIDKey = "vdcID"
+
 // VDC - Is the response structure for the GetVdc API.
 type VDC struct {
 	ID               int    `json:"Id,omitempty"`
@@ -126,7 +128,7 @@ func (v *VcloudClient) GetVDCByID(id int) (resp *VDC, err error) {
 		SetResult(&vdcResponse{}).
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vdcID": fmt.Sprintf("%d", id),
+			vdcIDKey: fmt.Sprintf("%d", id),
 		}).
 		Get("/v6/vcloud/vdcs/{vdcID}")
 	if err != nil {
@@ -227,7 +229,7 @@ func (vdc *VDC) ListProtectionLevels() (resp *ProtectionLevels, err error) {
 	r, err := c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vdcID": fmt.Sprintf("%d", vdc.GetID()),
+			vdcIDKey: fmt.Sprintf("%d", vdc.GetID()),
 		}).
 		SetResult(&protectionLevelAppliedResponse{}).
 		Get("/v6/vcloud/vdcs/{vdcID}/protected")
@@ -282,7 +284,7 @@ func (vdc *VDC) Protect(req ProtectUnprotectRequest) (job *commonnetbackup.JobAP
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vdcID": fmt.Sprintf("%d", vdc.GetID()),
+			vdcIDKey: fmt.Sprintf("%d", vdc.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),
@@ -334,7 +336,7 @@ func (vdc *VDC) Unprotect(req ProtectUnprotectRequest) (job *commonnetbackup.Job
 	r, err = c.R().
 		SetError(&commonnetbackup.APIError{}).
 		SetPathParams(map[string]string{
-			"vdcID": fmt.Sprintf("%d", vdc.GetID()),
+			vdcIDKey: fmt.Sprintf("%d", vdc.GetID()),
 		}).
 		SetBody(protectBody{
 			ProtectionLevelID: protectionLevel.GetID(),

--- a/v1/org/certificate_test.go
+++ b/v1/org/certificate_test.go
@@ -24,6 +24,13 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
+const (
+	testSuccess      = "success"
+	testCertName     = "test"
+	testCertName2    = "test2"
+	testRefreshError = "refresh-error"
+)
+
 func TestClient_ListCertificatesInLibrary(t *testing.T) {
 	// Mock controller.
 	ctrl := gomock.NewController(t)
@@ -42,47 +49,47 @@ func TestClient_ListCertificatesInLibrary(t *testing.T) {
 		err               error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetAllCertificatesFromLibrary(nil).Return([]*govcd.Certificate{
 					{
 						CertificateLibrary: &govcdtypes.CertificateLibraryItem{
-							Id:          "test",
-							Alias:       "test",
-							Description: "test",
-							Certificate: "test",
+							Id:          testCertName,
+							Alias:       testCertName,
+							Description: testCertName,
+							Certificate: testCertName,
 						},
 					},
 					{
 						CertificateLibrary: &govcdtypes.CertificateLibraryItem{
-							Id:          "test2",
-							Alias:       "test2",
-							Description: "test2",
-							Certificate: "test2",
+							Id:          testCertName2,
+							Alias:       testCertName2,
+							Description: testCertName2,
+							Certificate: testCertName2,
 						},
 					},
 				}, nil)
 			},
 			expectedCertValue: CertificatesModel{
 				{
-					ID:          "test",
-					Name:        "test",
-					Description: "test",
-					Certificate: "test",
+					ID:          testCertName,
+					Name:        testCertName,
+					Description: testCertName,
+					Certificate: testCertName,
 				},
 				{
-					ID:          "test2",
-					Name:        "test2",
-					Description: "test2",
-					Certificate: "test2",
+					ID:          testCertName2,
+					Name:        testCertName2,
+					Description: testCertName2,
+					Certificate: testCertName2,
 				},
 			},
 			expectedErr: false,
 			err:         nil,
 		},
 		{
-			name: "refresh-error",
+			name: testRefreshError,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},
@@ -152,24 +159,24 @@ func TestClient_GetCertificateFromLibrary(t *testing.T) {
 		err               error
 	}{
 		{
-			name:     "success",
-			nameOrID: "test",
+			name:     testSuccess,
+			nameOrID: testCertName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryByName(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
-						Id:          "test",
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Id:          testCertName,
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 			},
 			expectedCertValue: CertificateModel{
-				ID:          "test",
-				Name:        "test",
-				Description: "test",
-				Certificate: "test",
+				ID:          testCertName,
+				Name:        testCertName,
+				Description: testCertName,
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -182,24 +189,24 @@ func TestClient_GetCertificateFromLibrary(t *testing.T) {
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 			},
 			expectedCertValue: CertificateModel{
 				ID:          generatedValidID,
-				Name:        "test",
-				Description: "test",
-				Certificate: "test",
+				Name:        testCertName,
+				Description: testCertName,
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
 		},
 		{
-			name:     "refresh-error",
-			nameOrID: "test",
+			name:     testRefreshError,
+			nameOrID: testCertName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},
@@ -209,7 +216,7 @@ func TestClient_GetCertificateFromLibrary(t *testing.T) {
 		},
 		{
 			name:     "error-get-cert-by-name",
-			nameOrID: "test",
+			nameOrID: testCertName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryByName(gomock.Any()).Return(nil, errors.New("error"))
@@ -270,32 +277,32 @@ func TestClient_CreateCertificateInLibrary(t *testing.T) {
 		err               error
 	}{
 		{
-			name: "success",
+			name: testSuccess,
 			certificate: CertificateCreateRequest{
-				Name:        "test",
-				Description: "test",
-				Certificate: "test",
-				PrivateKey:  "test",
-				Passphrase:  "test",
+				Name:        testCertName,
+				Description: testCertName,
+				Certificate: testCertName,
+				PrivateKey:  testCertName,
+				Passphrase:  testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().AddCertificateToLibrary(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:                   generatedValidID,
-						Alias:                "test",
-						Description:          "test",
-						Certificate:          "test",
-						PrivateKey:           "test",
-						PrivateKeyPassphrase: "test",
+						Alias:                testCertName,
+						Description:          testCertName,
+						Certificate:          testCertName,
+						PrivateKey:           testCertName,
+						PrivateKeyPassphrase: testCertName,
 					},
 				}, nil)
 			},
 			expectedCertValue: CertificateModel{
 				ID:          generatedValidID,
-				Name:        "test",
-				Description: "test",
-				Certificate: "test",
+				Name:        testCertName,
+				Description: testCertName,
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -303,27 +310,27 @@ func TestClient_CreateCertificateInLibrary(t *testing.T) {
 		{
 			name: "success-no-description",
 			certificate: CertificateCreateRequest{
-				Name:        "test",
-				Certificate: "test",
-				PrivateKey:  "test",
-				Passphrase:  "test",
+				Name:        testCertName,
+				Certificate: testCertName,
+				PrivateKey:  testCertName,
+				Passphrase:  testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().AddCertificateToLibrary(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
+						Alias:       testCertName,
 						Description: "",
-						Certificate: "test",
+						Certificate: testCertName,
 					},
 				}, nil)
 			},
 			expectedCertValue: CertificateModel{
 				ID:          generatedValidID,
-				Name:        "test",
+				Name:        testCertName,
 				Description: "",
-				Certificate: "test",
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -331,7 +338,7 @@ func TestClient_CreateCertificateInLibrary(t *testing.T) {
 		{
 			name: "error-validation",
 			certificate: CertificateCreateRequest{
-				Name:        "test",
+				Name:        testCertName,
 				Certificate: "",
 			},
 			mockFunc: func() {
@@ -341,7 +348,7 @@ func TestClient_CreateCertificateInLibrary(t *testing.T) {
 			expectedErr:       true,
 		},
 		{
-			name: "refresh-error",
+			name: testRefreshError,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},
@@ -352,8 +359,8 @@ func TestClient_CreateCertificateInLibrary(t *testing.T) {
 		{
 			name: "error-add-cert",
 			certificate: CertificateCreateRequest{
-				Name:        "test",
-				Certificate: "test",
+				Name:        testCertName,
+				Certificate: testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -406,38 +413,38 @@ func TestClient_UpdateCertificateInLibrary(t *testing.T) {
 		err               error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			certificateID: generatedValidID,
 			certificate: CertificateUpdateRequest{
-				Name:        "test",
-				Description: "test",
+				Name:        testCertName,
+				Description: testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 				updateCertificateInLibrary = func(_ internalCertificateClient) (*govcd.Certificate, error) {
 					return &govcd.Certificate{
 						CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 							Id:          generatedValidID,
-							Alias:       "test",
-							Description: "test",
-							Certificate: "test",
+							Alias:       testCertName,
+							Description: testCertName,
+							Certificate: testCertName,
 						},
 					}, nil
 				}
 			},
 			expectedCertValue: CertificateModel{
 				ID:          generatedValidID,
-				Name:        "test",
-				Description: "test",
-				Certificate: "test",
+				Name:        testCertName,
+				Description: testCertName,
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -446,34 +453,34 @@ func TestClient_UpdateCertificateInLibrary(t *testing.T) {
 			name:          "success-no-description",
 			certificateID: generatedValidID,
 			certificate: CertificateUpdateRequest{
-				Name: "test",
+				Name: testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 				updateCertificateInLibrary = func(_ internalCertificateClient) (*govcd.Certificate, error) {
 					return &govcd.Certificate{
 						CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 							Id:          generatedValidID,
-							Alias:       "test",
+							Alias:       testCertName,
 							Description: "",
-							Certificate: "test",
+							Certificate: testCertName,
 						},
 					}, nil
 				}
 			},
 			expectedCertValue: CertificateModel{
 				ID:          generatedValidID,
-				Name:        "test",
+				Name:        testCertName,
 				Description: "",
-				Certificate: "test",
+				Certificate: testCertName,
 			},
 			expectedErr: false,
 			err:         nil,
@@ -491,8 +498,8 @@ func TestClient_UpdateCertificateInLibrary(t *testing.T) {
 			expectedErr:       true,
 		},
 		{
-			name:          "refresh-error",
-			certificateID: "test",
+			name:          testRefreshError,
+			certificateID: testCertName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},
@@ -504,7 +511,7 @@ func TestClient_UpdateCertificateInLibrary(t *testing.T) {
 			name:          "error-get-cert",
 			certificateID: generatedValidID,
 			certificate: CertificateUpdateRequest{
-				Name: "test",
+				Name: testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
@@ -517,16 +524,16 @@ func TestClient_UpdateCertificateInLibrary(t *testing.T) {
 			name:          "error-update-cert",
 			certificateID: generatedValidID,
 			certificate: CertificateUpdateRequest{
-				Name: "test",
+				Name: testCertName,
 			},
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 				updateCertificateInLibrary = func(_ internalCertificateClient) (*govcd.Certificate, error) {
@@ -578,16 +585,16 @@ func TestClient_DeleteCertificateFromLibrary(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "success",
+			name:          testSuccess,
 			certificateID: generatedValidID,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(nil)
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 				deleteCertificateFromLibrary = func(_ internalCertificateClient) error {
@@ -614,9 +621,9 @@ func TestClient_DeleteCertificateFromLibrary(t *testing.T) {
 				clientCAV.EXPECT().GetCertificateFromLibraryById(gomock.Any()).Return(&govcd.Certificate{
 					CertificateLibrary: &govcdtypes.CertificateLibraryItem{
 						Id:          generatedValidID,
-						Alias:       "test",
-						Description: "test",
-						Certificate: "test",
+						Alias:       testCertName,
+						Description: testCertName,
+						Certificate: testCertName,
 					},
 				}, nil)
 				deleteCertificateFromLibrary = func(_ internalCertificateClient) error {
@@ -626,8 +633,8 @@ func TestClient_DeleteCertificateFromLibrary(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name:          "refresh-error",
-			certificateID: "test",
+			name:          testRefreshError,
+			certificateID: testCertName,
 			mockFunc: func() {
 				clientCAV.EXPECT().Refresh().Return(errors.New("error"))
 			},

--- a/v1/org/properties_test.go
+++ b/v1/org/properties_test.go
@@ -24,6 +24,12 @@ import (
 	commoncloudavenue "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/cloudavenue"
 )
 
+const (
+	testOwnerName        = "John Doe"
+	testOwnerDescription = "John Doe description"
+	testBillingModel     = "PAYG"
+)
+
 func TestClient_GetProperties(t *testing.T) {
 	// Mock controller.
 	ctrl := gomock.NewController(t)
@@ -56,10 +62,10 @@ func TestClient_GetProperties(t *testing.T) {
 				})
 			},
 			expectedValues: PropertiesModel{
-				FullName:     "John Doe",
-				Description:  "John Doe description",
+				FullName:     testOwnerName,
+				Description:  testOwnerDescription,
 				Email:        "",
-				BillingModel: "PAYG",
+				BillingModel: testBillingModel,
 			},
 			expectedErr: false,
 		},
@@ -168,10 +174,10 @@ func TestClient_UpdateProperties(t *testing.T) {
 				})
 			},
 			properties: PropertiesRequest{
-				FullName:     "John Doe",
-				Description:  "John Doe description",
+				FullName:     testOwnerName,
+				Description:  testOwnerDescription,
 				Email:        "",
-				BillingModel: "PAYG",
+				BillingModel: testBillingModel,
 			},
 			expectedErr: false,
 		},
@@ -224,10 +230,10 @@ func TestClient_UpdateProperties(t *testing.T) {
 				})
 			},
 			properties: PropertiesRequest{
-				FullName:     "John Doe",
-				Description:  "John Doe description",
+				FullName:     testOwnerName,
+				Description:  testOwnerDescription,
 				Email:        "",
-				BillingModel: "PAYG",
+				BillingModel: testBillingModel,
 			},
 			expectedErr: true,
 		},
@@ -247,10 +253,10 @@ func TestClient_UpdateProperties(t *testing.T) {
 				})
 			},
 			properties: PropertiesRequest{
-				FullName:     "John Doe",
-				Description:  "John Doe description",
+				FullName:     testOwnerName,
+				Description:  testOwnerDescription,
 				Email:        "",
-				BillingModel: "PAYG",
+				BillingModel: testBillingModel,
 			},
 			expectedErr: true,
 		},

--- a/v1/querier.go
+++ b/v1/querier.go
@@ -37,6 +37,8 @@ func (v *Query) Get() *Get {
 	return &Get{}
 }
 
+const filterKey = "filter"
+
 type objectType string
 
 const (
@@ -96,8 +98,8 @@ func queryGet(objectType objectType, name string) (govcd.Results, error) {
 	}
 
 	return c.Vmware.Query(map[string]string{
-		"type":   string(objectType),
-		"filter": "name==" + name,
+		"type":    string(objectType),
+		filterKey: "name==" + name,
 	})
 }
 
@@ -145,7 +147,7 @@ func (q *Get) VAPP(vappName string) (*types.QueryResultVAppRecordType, error) {
 // VM list all vm informations.
 func (q *List) VM(vAppName string) ([]*types.QueryResultVMRecordType, error) {
 	r, err := queryListWithOptionalFilter(typeVM, map[string]string{
-		"filter": "containerName==" + vAppName,
+		filterKey: "containerName==" + vAppName,
 	})
 
 	for _, vm := range r.Results.VMRecord {
@@ -163,8 +165,8 @@ func (q *List) VM(vAppName string) ([]*types.QueryResultVMRecordType, error) {
 // VM get a vm informations by name.
 func (q *Get) VM(vmName, vAppName string) (*types.QueryResultVMRecordType, error) {
 	r, err := queryGetWithOptionalFilter(typeVM, vmName, map[string]string{
-		"filter": "containerName==" + vAppName,
-		"name":   vmName,
+		filterKey: "containerName==" + vAppName,
+		"name":    vmName,
 	})
 	if r.Results.VMRecord == nil {
 		return nil, err

--- a/v1/s3_credential.go
+++ b/v1/s3_credential.go
@@ -102,6 +102,11 @@ func (c *S3Credential) IsProviderOwner() bool {
 	return c.ProviderOwner
 }
 
+const (
+	orgIDKey    = "orgID"
+	userNameKey = "userName"
+)
+
 // GetCredentials - Get a list of credentials.
 func (s *S3User) GetCredentials() (resp *S3Credentials, err error) {
 	type allCredentials struct {
@@ -111,8 +116,8 @@ func (s *S3User) GetCredentials() (resp *S3Credentials, err error) {
 	r, err := clients3.NewOSE().R().
 		SetResult(&allCredentials{}).
 		SetPathParams(map[string]string{
-			"orgID":    clients3.GetOrganizationID(),
-			"userName": s.GetName(),
+			orgIDKey:    clients3.GetOrganizationID(),
+			userNameKey: s.GetName(),
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users/{userName}/credentials")
 	if err != nil {
@@ -131,8 +136,8 @@ func (s *S3User) GetCredential(accessKey string) (resp *S3Credential, err error)
 	r, err := clients3.NewOSE().R().
 		SetResult(&S3Credential{}).
 		SetPathParams(map[string]string{
-			"orgID":     clients3.GetOrganizationID(),
-			"userName":  s.GetName(),
+			orgIDKey:    clients3.GetOrganizationID(),
+			userNameKey: s.GetName(),
 			"accessKey": accessKey,
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users/{userName}/credentials/{accessKey}")
@@ -152,8 +157,8 @@ func (s *S3User) NewCredential() (resp *S3Credential, err error) {
 	r, err := clients3.NewOSE().R().
 		SetResult(&S3Credential{}).
 		SetPathParams(map[string]string{
-			"orgID":    clients3.GetOrganizationID(),
-			"userName": s.Name,
+			orgIDKey:    clients3.GetOrganizationID(),
+			userNameKey: s.Name,
 		}).
 		Post("/api/v1/core/tenants/{orgID}/users/{userName}/credentials")
 	if err != nil {
@@ -171,8 +176,8 @@ func (s *S3User) NewCredential() (resp *S3Credential, err error) {
 func (c *S3Credential) Delete() (err error) {
 	r, err := clients3.NewOSE().R().
 		SetPathParams(map[string]string{
-			"orgID":     clients3.GetOrganizationID(),
-			"userName":  c.GetOwner(),
+			orgIDKey:    clients3.GetOrganizationID(),
+			userNameKey: c.GetOwner(),
 			"accessKey": c.GetAccessKey(),
 		}).
 		Delete("/api/v1/core/tenants/{orgID}/users/{userName}/credentials/{accessKey}")

--- a/v1/s3_user.go
+++ b/v1/s3_user.go
@@ -139,8 +139,8 @@ func (s S3Client) GetUser(username string) (resp *S3User, err *OSEError) {
 		SetResult(&S3User{}).
 		SetError(&OSEError{}).
 		SetPathParams(map[string]string{
-			"orgID":    clients3.GetOrganizationID(),
-			"userName": username,
+			orgIDKey:    clients3.GetOrganizationID(),
+			userNameKey: username,
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users/{userName}")
 	if errA != nil {
@@ -164,8 +164,8 @@ func (s *S3User) GetCanonicalID() (resp string, err error) {
 		r, err := clients3.NewOSE().R().
 			SetResult(&resp).
 			SetPathParams(map[string]string{
-				"orgID":    clients3.GetOrganizationID(),
-				"userName": s.GetName(),
+				orgIDKey:    clients3.GetOrganizationID(),
+				userNameKey: s.GetName(),
 			}).
 			Get("/api/v1/core/tenants/{orgID}/users/{userName}/canonical-id")
 		if err != nil {
@@ -193,7 +193,7 @@ func (s S3Client) GetUsers() (resp *S3Users, err error) {
 	r, err := clients3.NewOSE().R().
 		SetResult(&allUsers{}).
 		SetPathParams(map[string]string{
-			"orgID": clients3.GetOrganizationID(),
+			orgIDKey: clients3.GetOrganizationID(),
 		}).
 		Get("/api/v1/core/tenants/{orgID}/users")
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes CI Release failure caused by `goconst` lint violations.

- Extract all repeated string literals (≥3 occurrences) as named constants
- Auto-fix `gci` import formatting on touched files
- Remove unused `//nolint:gosec` directive in `v1/edgegw.go`

## Packages fixed

| Package | Type |
|---------|------|
| `pkg/clients/consoles/` | test files |
| `pkg/clients/netbackup/` | test files |
| `pkg/urn/` | test files |
| `v1/edgegateway/` | production + test files |
| `v1/edgeloadbalancer/` | test files (new `testdata_test.go`) |
| `v1/iam/` | test files |
| `v1/netbackup/` | production files |
| `v1/org/` | test files |
| `v1/querier.go` | production file |
| `v1/s3_credential.go` / `v1/s3_user.go` | production files |

## Changes

- **28 files** modified, 1 new file created (`v1/edgeloadbalancer/testdata_test.go`)
- Pure mechanical refactor — no behavioral change, no logic touched
- `golangci-lint run` → **0 issues** on all touched packages

Closes #308

## CI reference

https://github.com/orange-cloudavenue/cloudavenue-sdk-go/actions/runs/25321049513/job/74229962845