### PR TITLE
fix: bypass GetBandwidthCapacityRemaining for dedicated T0 VRFs

### DIFF
--- a/.changelog/312.txt
+++ b/.changelog/312.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`v1/edgegw` - Add sentinel errors `ErrNoBandwidthCapacityRemaining` and `ErrDedicatedT0BandwidthNotComputable` to properly surface bandwidth capacity issues. Fix silent overcommit in `GetBandwidthCapacityRemaining()` for dedicated VRF T0 types (`VRF_DEDICATED_MEDIUM`, `VRF_DEDICATED_LARGE`) where the API returns `rateLimit=0`; the calculation is now bypassed and returns `ErrDedicatedT0BandwidthNotComputable` for these types. Add `IsVRFDedicated()` helper on T0 to identify dedicated VRF gateways. Related to provider issue #1229 and SDK issue #311.
+```

--- a/v1/cloudavenue_t0.go
+++ b/v1/cloudavenue_t0.go
@@ -129,6 +129,12 @@ func (c ClassService) IsVRFDedicatedLarge() bool {
 	return c == T0ClassServiceVRFDedicatedLarge
 }
 
+// IsVRFDedicated returns true if the class service is VRF_DEDICATED_MEDIUM or VRF_DEDICATED_LARGE.
+// Update this method when new dedicated VRF classes are added.
+func (c ClassService) IsVRFDedicated() bool {
+	return c.IsVRFDedicatedMedium() || c.IsVRFDedicatedLarge()
+}
+
 // * List
 
 // GetT0s - Returns the list of T0s.

--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -10,6 +10,7 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -24,6 +25,15 @@ import (
 )
 
 const edgeIDKey = "EdgeID"
+
+var (
+	// ErrNoBandwidthCapacityRemaining is returned when the T0 VRF has no remaining bandwidth capacity.
+	ErrNoBandwidthCapacityRemaining = errors.New("no bandwidth capacity remaining")
+	// ErrDedicatedT0BandwidthNotComputable is returned when the T0 VRF is dedicated and the API
+	// returns rateLimit=0 for all edge gateways, making the calculation unreliable.
+	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
+	ErrDedicatedT0BandwidthNotComputable = errors.New("dedicated T0 bandwidth not computable")
+)
 
 type (
 	EdgeGateway struct{}
@@ -93,6 +103,18 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 		return response, err
 	}
 
+	// WORKAROUND: The CloudAvenue API returns rateLimit=0 for all edge gateways
+	// attached to a VRF_DEDICATED_MEDIUM or VRF_DEDICATED_LARGE T0. As a result,
+	// subtracting each edge's bandwidth from the total would always yield the full
+	// T0 capacity, as if no edge were consuming any bandwidth — which is incorrect
+	// and could lead to silent overcommit.
+	// This guard bypasses the unreliable calculation until the API is fixed.
+	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
+	if t0.GetClassService().IsVRFDedicated() {
+		return 0, fmt.Errorf("%w: dedicated T0 %q (class %s) — API returns rateLimit=0 for edge gateways, calculation unreliable",
+			ErrDedicatedT0BandwidthNotComputable, t0VrfName, t0.GetClassService())
+	}
+
 	t0BandwidthCapacity, err := t0.GetBandwidthCapacity()
 	if err != nil {
 		return response, err
@@ -106,7 +128,7 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 
 	// 5 Mbps is the minimum bandwidth capacity
 	if t0BandwidthCapacity < 5 {
-		return 0, fmt.Errorf("no bandwidth capacity remaining")
+		return 0, fmt.Errorf("%w for T0 %q", ErrNoBandwidthCapacityRemaining, t0VrfName)
 	}
 
 	return t0BandwidthCapacity, nil
@@ -363,7 +385,7 @@ func (n NetworkType) GetEndAddress() string {
 	broadcast := numIPs - 1
 	end := make(net.IP, 4)
 	for i := 0; i < 4; i++ {
-		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff)
+		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //#nosec G115 -- safe: masked to 8 bits before conversion
 	}
 
 	return end.String()


### PR DESCRIPTION
## Summary

- Add sentinel errors `ErrNoBandwidthCapacityRemaining` and `ErrDedicatedT0BandwidthNotComputable` to allow callers to discriminate error cases via `errors.Is()`
- Add `IsVRFDedicated()` helper on `ClassService`
- Bypass `GetBandwidthCapacityRemaining()` for dedicated T0s (`VRF_DEDICATED_MEDIUM`/`VRF_DEDICATED_LARGE`) — the CloudAvenue API returns `rateLimit=0` for edge gateways on these T0s, making the remaining bandwidth calculation unreliable and leading to silent overcommit

## Root cause

API bug: `GET /v2.0/edges` returns `"rateLimit": 0` for edge gateways on dedicated T0s.

## Closes

Closes #311
Related: orange-cloudavenue/terraform-provider-cloudavenue#1229