### PR TITLE
fix(vdc): prevent partial object return in GetVDC when one source fails

### DIFF
--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -10,6 +10,7 @@
 package v1
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -24,6 +25,15 @@ import (
 )
 
 const edgeIDKey = "EdgeID"
+
+var (
+	// ErrNoBandwidthCapacityRemaining is returned when the T0 VRF has no remaining bandwidth capacity.
+	ErrNoBandwidthCapacityRemaining = errors.New("no bandwidth capacity remaining")
+	// ErrDedicatedT0BandwidthNotComputable is returned when the T0 VRF is dedicated and the API
+	// returns rateLimit=0 for all edge gateways, making the calculation unreliable.
+	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
+	ErrDedicatedT0BandwidthNotComputable = errors.New("dedicated T0 bandwidth not computable")
+)
 
 type (
 	EdgeGateway struct{}
@@ -93,6 +103,18 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 		return response, err
 	}
 
+	// WORKAROUND: The CloudAvenue API returns rateLimit=0 for all edge gateways
+	// attached to a VRF_DEDICATED_MEDIUM or VRF_DEDICATED_LARGE T0. As a result,
+	// subtracting each edge's bandwidth from the total would always yield the full
+	// T0 capacity, as if no edge were consuming any bandwidth — which is incorrect
+	// and could lead to silent overcommit.
+	// This guard bypasses the unreliable calculation until the API is fixed.
+	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
+	if t0.GetClassService().IsVRFDedicated() {
+		return 0, fmt.Errorf("%w: dedicated T0 %q (class %s) — API returns rateLimit=0 for edge gateways, calculation unreliable",
+			ErrDedicatedT0BandwidthNotComputable, t0VrfName, t0.GetClassService())
+	}
+
 	t0BandwidthCapacity, err := t0.GetBandwidthCapacity()
 	if err != nil {
 		return response, err
@@ -106,7 +128,7 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 
 	// 5 Mbps is the minimum bandwidth capacity
 	if t0BandwidthCapacity < 5 {
-		return 0, fmt.Errorf("no bandwidth capacity remaining")
+		return 0, fmt.Errorf("%w for T0 %q", ErrNoBandwidthCapacityRemaining, t0VrfName)
 	}
 
 	return t0BandwidthCapacity, nil
@@ -363,7 +385,7 @@ func (n NetworkType) GetEndAddress() string {
 	broadcast := numIPs - 1
 	end := make(net.IP, 4)
 	for i := 0; i < 4; i++ {
-		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //nolint:gosec // G115: intentional network mask calculation, &0xff guarantees byte range
+		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //#nosec G115 -- safe: masked to 8 bits before conversion
 	}
 
 	return end.String()

--- a/v1/edgegw.go
+++ b/v1/edgegw.go
@@ -10,7 +10,6 @@
 package v1
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -25,15 +24,6 @@ import (
 )
 
 const edgeIDKey = "EdgeID"
-
-var (
-	// ErrNoBandwidthCapacityRemaining is returned when the T0 VRF has no remaining bandwidth capacity.
-	ErrNoBandwidthCapacityRemaining = errors.New("no bandwidth capacity remaining")
-	// ErrDedicatedT0BandwidthNotComputable is returned when the T0 VRF is dedicated and the API
-	// returns rateLimit=0 for all edge gateways, making the calculation unreliable.
-	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
-	ErrDedicatedT0BandwidthNotComputable = errors.New("dedicated T0 bandwidth not computable")
-)
 
 type (
 	EdgeGateway struct{}
@@ -103,18 +93,6 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 		return response, err
 	}
 
-	// WORKAROUND: The CloudAvenue API returns rateLimit=0 for all edge gateways
-	// attached to a VRF_DEDICATED_MEDIUM or VRF_DEDICATED_LARGE T0. As a result,
-	// subtracting each edge's bandwidth from the total would always yield the full
-	// T0 capacity, as if no edge were consuming any bandwidth — which is incorrect
-	// and could lead to silent overcommit.
-	// This guard bypasses the unreliable calculation until the API is fixed.
-	// See: https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1229
-	if t0.GetClassService().IsVRFDedicated() {
-		return 0, fmt.Errorf("%w: dedicated T0 %q (class %s) — API returns rateLimit=0 for edge gateways, calculation unreliable",
-			ErrDedicatedT0BandwidthNotComputable, t0VrfName, t0.GetClassService())
-	}
-
 	t0BandwidthCapacity, err := t0.GetBandwidthCapacity()
 	if err != nil {
 		return response, err
@@ -128,7 +106,7 @@ func (e *EdgeGateways) GetBandwidthCapacityRemaining(t0VrfName string) (response
 
 	// 5 Mbps is the minimum bandwidth capacity
 	if t0BandwidthCapacity < 5 {
-		return 0, fmt.Errorf("%w for T0 %q", ErrNoBandwidthCapacityRemaining, t0VrfName)
+		return 0, fmt.Errorf("no bandwidth capacity remaining")
 	}
 
 	return t0BandwidthCapacity, nil
@@ -385,7 +363,7 @@ func (n NetworkType) GetEndAddress() string {
 	broadcast := numIPs - 1
 	end := make(net.IP, 4)
 	for i := 0; i < 4; i++ {
-		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //#nosec G115 -- safe: masked to 8 bits before conversion
+		end[i] = start[i] + byte((broadcast>>uint(8*i))&0xff) //nolint:gosec // G115: intentional network mask calculation, &0xff guarantees byte range
 	}
 
 	return end.String()

--- a/v1/vdc.go
+++ b/v1/vdc.go
@@ -11,6 +11,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -40,10 +41,10 @@ var (
 // It returns a pointer to the VDC and an error if any.
 // The function performs concurrent requests to retrieve the VDC from both the VMware and the infrapi.
 // It uses goroutines and channels to handle the concurrent requests and waits for all goroutines to finish using a WaitGroup.
-// The function returns the VDC that was successfully retrieved from either the VMware or the infrapi.
+// Both lookups (VMware and InfrAPI) must succeed: if either source returns an error, the function returns nil and the error.
 func (v *CAVVdc) GetVDC(vdcName string) (*VDC, error) {
 	if vdcName == "" {
-		return nil, fmt.Errorf("%w", ErrEmptyVDCNameProvided)
+		return nil, ErrEmptyVDCNameProvided
 	}
 
 	c, err := clientcloudavenue.New()
@@ -57,12 +58,8 @@ func (v *CAVVdc) GetVDC(vdcName string) (*VDC, error) {
 	// channels
 	var (
 		errChan = make(chan error, 2)
-		vdcChan = make(chan interface{}, 2)
-		done    = make(chan bool)
+		vdcChan = make(chan any, 2)
 	)
-
-	defer close(errChan)
-	defer close(vdcChan)
 
 	getVDC := new(VDC)
 
@@ -91,10 +88,7 @@ func (v *CAVVdc) GetVDC(vdcName string) (*VDC, error) {
 		vdcChan <- vdc
 	}()
 
-	go func() {
-		wg.Wait()
-		done <- true
-	}()
+	wg.Wait()
 
 	errs := []error{}
 
@@ -102,9 +96,6 @@ func (v *CAVVdc) GetVDC(vdcName string) (*VDC, error) {
 		select {
 		case err := <-errChan:
 			errs = append(errs, err)
-			if len(errs) == 2 {
-				return nil, fmt.Errorf("errors: %v", errs)
-			}
 		case vdc := <-vdcChan:
 			switch x := vdc.(type) {
 			case *govcd.Vdc:
@@ -114,9 +105,16 @@ func (v *CAVVdc) GetVDC(vdcName string) (*VDC, error) {
 			default:
 				return nil, fmt.Errorf("unknown type %T", x)
 			}
-		case <-done:
-			break
 		}
+	}
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("%w: %s: %w", ErrRetrievingVDC, vdcName, errors.Join(errs...))
+	}
+
+	// Defensive guard: should not be reachable under current logic, but protects against future goroutine changes.
+	if getVDC.Vdc == nil || getVDC.infrapi == nil {
+		return nil, fmt.Errorf("%w: %s: incomplete VDC object retrieved", ErrRetrievingVDC, vdcName)
 	}
 
 	return getVDC, nil


### PR DESCRIPTION
## Summary

Fixes #310 — `GetVDC` retournait silencieusement un objet `*VDC` partiel (`infrapi == nil`) quand la goroutine InfrAPI échouait seule, provoquant un `panic: nil pointer dereference` sur tous les getters InfrAPI (`GetDescription`, `GetBillingModel`, etc.).

## Root cause

La boucle `for i := 0; i < 2; i++` n'échouait que si les deux goroutines échouaient (`if len(errs) == 2`). Une seule erreur → objet partiel retourné sans erreur.

## Changes

### `v1/vdc.go`
- Accumulation des erreurs déplacée après la boucle : toute erreur d'une source unique retourne `nil` + `ErrRetrievingVDC` wrappé
- Goroutine sentinel + canal `done` supprimés → remplacés par `wg.Wait()` bloquant direct (élimine la race condition et le goroutine leak)
- `defer close()` supprimés (risque de panic `send on closed channel` sur early return)
- Nil-guard défensif ajouté après la vérification d'erreur
- `fmt.Errorf("%w", ErrEmptyVDCNameProvided)` → `return nil, ErrEmptyVDCNameProvided`
- `interface{}` → `any` (Go 1.18+)
- Commentaire de doc mis à jour

### `v1/edgegw.go`
- `//nolint:gosec` sur le G115 préexistant (overflow intentionnel, `&0xff` garantit la plage byte)

## Behavior after fix

| Scénario | Avant | Après |
|---|---|---|
| VMware ✓ + InfrAPI ✓ | `*VDC` complet | `*VDC` complet ✓ |
| VMware ✓ + InfrAPI ✗ | `*VDC` partiel → **panic** | `nil` + erreur ✓ |
| VMware ✗ + InfrAPI ✓ | `*VDC` partiel → **panic** | `nil` + erreur ✓ |
| VMware ✗ + InfrAPI ✗ | `nil` + erreur | `nil` + erreur jointe ✓ |

`GetVDCOrVDCGroup` bénéficie du fix automatiquement.